### PR TITLE
Not friendly to non-ascii data

### DIFF
--- a/nidm/experiment/Core.py
+++ b/nidm/experiment/Core.py
@@ -329,7 +329,7 @@ class Core(object):
         "startedAtTime": { "@type": "xsd:dateTime", "@id": "prov:startedAtTime" },
         "endedAtTime": { "@type": "xsd:dateTime", "@id": "prov:endedAtTime" }
         }
-        return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
+        return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4)
 
     def save_DotGraph(self,filename,format=None):
         dot = prov_to_dot(self.graph)

--- a/nidm/experiment/tools/BIDSMRI2NIDM.py
+++ b/nidm/experiment/tools/BIDSMRI2NIDM.py
@@ -91,7 +91,7 @@ def main(argv):
         if args.jsonld:
             f.write(project.serializeJSONLD())
         else:
-            f.write(project.serializeTurtle())
+            f.write(project.serializeTurtle().decode('ASCII'))
         #f.write(project.graph.get_provn())
     #save a DOT graph as PNG
     project.save_DotGraph(str(outputfile + ".png"), format="png")


### PR DESCRIPTION
Russia is our friend!

from participants.tsv (valid UTF-8)
```
sub-01\tm\t30-35\tr\tn\tрусский
```

leads to 

```
  File "/home/mih/hacking/PyNIDM/nidm/experiment/Core.py", line 332, in serializeJSONLD
    return rdf_graph_parse.serialize(format='json-ld', context=context, indent=4).decode('ASCII')
```

the decode part is the issue.