### PR TITLE
calling query command in nidm_query

### DIFF
--- a/nidm/experiment/tools/nidm_query.py
+++ b/nidm/experiment/tools/nidm_query.py
@@ -58,6 +58,9 @@ def query(nidm_file_list, query_file, output_file):
         query = fp.read()
     df = sparql_query_nidm(nidm_file_list.split(','),query,output_file)
 
-
     return df
 
+
+# it can be used calling the script `python nidm_query.py -nl ... -q ..
+if __name__ == "__main__":
+    query()

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ opts = dict(name=NAME,
             requires=REQUIRES,
             entry_points='''
                [console_scripts]
-               pynidm=nidm.experiment.tools.click_main:cli
+               nidm=nidm.experiment.tools.click_main:cli
             '''
 )
 


### PR DESCRIPTION
* I added the execution of `query` command, so you can call `python nidm_query.py -nl .. -q ..`.

(there is also option of calling `query.callback()`, but then you have to provide all arguments in `callback`.)

* changing command name to `nidm`