### PR TITLE
Implemented GetProjectMetadata and GetProjectComputedMetadataa

### DIFF
--- a/nidm/core/Constants.py
+++ b/nidm/core/Constants.py
@@ -313,6 +313,21 @@ NIDM_ACQUISITION_MODALITY = QualifiedName(provNamespace("nidm",NIDM),"Acquisitio
 NIDM_ASSESSMENT_ACQUISITION = QualifiedName(provNamespace("onli", ONLI), "instrument-based-assessment")
 NIDM_ACQUISITION_ENTITY = QualifiedName(provNamespace("nidm", NIDM), "AcquisitionObject")
 
+NIDM_PROJECT_SOURCE = QualifiedName(provNamespace("dctypes", DCTYPES), "source")
+NIDM_HAD_NUMERICAL_VALUE = QualifiedName(provNamespace("nidm", NIDM), "hadNumericalValue")
+NIDM_BATH_SOLUTION = QualifiedName(provNamespace("nidm", NIDM), "BathSolution")
+NIDM_CELL_TYPE = QualifiedName(provNamespace("nidm", NIDM), "CellType")
+NIDM_CHANNEL_NUMBER = QualifiedName(provNamespace("nidm", NIDM), "ChannelNumber")
+NIDM_ELECTRODE_IMPEDANCE = QualifiedName(provNamespace("nidm", NIDM), "ElectrodeImpedance")
+NIDM_GROUP_LABEL = QualifiedName(provNamespace("nidm", NIDM), "GroupLabel")
+NIDM_HOLLOW_ELECTRODE_SOLUTION = QualifiedName(provNamespace("nidm", NIDM), "HollowElectrodeSolution")
+NIDM_HAD_IMAGE_CONTRACT_TYPE = QualifiedName(provNamespace("nidm", NIDM), "hadImageContractType")
+NIDM_HAD_IMAGE_USAGE_TYPE = QualifiedName(provNamespace("nidm", NIDM), "hadImageUsageType")
+NIDM_NUBMER_OF_CHANNELS = QualifiedName(provNamespace("nidm", NIDM), "NubmerOfChannels")
+NIDM_APPLIED_FILTER = QualifiedName(provNamespace("nidm", NIDM), "AppliedFilter")
+NIDM_SOLUTION_FLOW_SPEED = QualifiedName(provNamespace("nidm", NIDM), "SolutionFlowSpeed")
+NIDM_RECORDING_LOCATION = QualifiedName(provNamespace("nidm", NIDM), "RecordingLocation")
+
 NIDM_DEMOGRAPHICS_ENTITY = QualifiedName(provNamespace("nidm", NIDM), "DemographicsInstrument")
 NIDM_ASSESSMENT_USAGE_TYPE = QualifiedName(provNamespace("nidm", NIDM),"AssessmentUsageType")
 

--- a/nidm/experiment/Query.py
+++ b/nidm/experiment/Query.py
@@ -38,7 +38,8 @@ import logging
 from .Utils import read_nidm
 from .Project import Project
 from nidm.core import Constants
-from json import dumps
+from json import dumps, loads
+import re
 
 def sparql_query_nidm(nidm_file_list,query, output_file=None, return_graph=False):
     '''
@@ -299,3 +300,150 @@ def GetProjectInstruments(nidm_file_list, project_id):
     results = df.to_dict()
     logging.info(results)
     return df['assessment_type'].tolist()
+
+
+def GetProjectsMetadata(nidm_file_list):
+    '''
+     :param nidm_file_list: List of one or more NIDM files to query for project meta data
+    :return: dataframe with two columns: "project_uuid" and "project_dentifier"
+    '''
+
+    query = '''
+        PREFIX sio: <http://semanticscience.org/ontology/sio.owl#>
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX nidm:<http://purl.org/nidash/nidm#>
+         SELECT DISTINCT ?property ?o ?s WHERE {{ ?s a nidm:Project . ?s ?property ?o }}
+    '''
+    df = sparql_query_nidm(nidm_file_list, query, output_file=None)
+
+    projects = {}
+    arr = df.values
+
+    for row in arr:
+        field = str(row[0])
+        value = str(row[1])
+        project = str(row[2])
+        if project not in projects:
+            projects[str(project)] = {}
+        # if field in field_whitelist:
+        projects[str(project)][field] = value
+
+    return (dumps({'projects': compressForJSONResponse(projects)}))
+
+
+def GetProjectsComputedMetadata(nidm_file_list):
+    '''
+     :param nidm_file_list: List of one or more NIDM files to query across for list of Projects
+    :return: dataframe with two columns: "project_uuid" and "project_dentifier"
+    '''
+
+    meta_data = loads(GetProjectsMetadata(nidm_file_list))
+    ExtractProjectSummary(meta_data, nidm_file_list)
+    compressed_meta_data = compressForJSONResponse(meta_data)
+
+    return (dumps(compressed_meta_data))
+
+
+def ExtractProjectSummary(meta_data, nidm_file_list):
+    '''
+
+    :param meta_data: a dictionary of projects containing their meta data as pulled from the nidm_file_list
+    :param nidm_file_list: List of NIDM files
+    :return:
+    '''
+    query = '''
+    PREFIX nidm:<http://purl.org/nidash/nidm#>
+        PREFIX prov: <http://www.w3.org/ns/prov#>
+        PREFIX ncicb: <http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#>
+        PREFIX ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/>
+        PREFIX obo: <http://purl.obolibrary.org/obo/>
+        PREFIX dct: <http://purl.org/dc/terms/>
+        SELECT DISTINCT ?id ?age ?gender ?hand ?assessment ?project
+        WHERE {
+          ?assessment prov:wasGeneratedBy ?acq .
+          ?acq prov:wasAssociatedWith ?person .
+          ?assessment ncicb:Age ?age .
+          ?assessment ndar:gender ?gender .
+          ?assessment obo:handedness ?hand .
+          ?person ndar:src_subject_id ?id .
+          ?acq dct:isPartOf ?activity .
+          ?activity dct:isPartOf ?project .
+          ?project a nidm:Project
+        }
+      '''
+
+    df = sparql_query_nidm(nidm_file_list, query, output_file=None)
+    projects = meta_data['projects']
+
+    arr = df.values
+    key = str(Constants.NIDM_NUMBER_OF_SUBJECTS)
+    for project_id, project in projects.items():
+        project[key] = 0
+        project['age_max'] = 0
+        project['age_min'] = sys.maxsize
+        project[str(Constants.NIDM_GENDER)] = []
+
+    for row in arr:
+        project_id = matchPrefix( str(row[5]) ) # 5th column is the project UUID
+        projects[project_id][str(Constants.NIDM_NUMBER_OF_SUBJECTS)] += 1
+
+        age = float(row[1])  # 1st column is age
+        projects[project_id]['age_min'] = min(age, projects[project_id]['age_min'])
+        projects[project_id]['age_max'] = max(age, projects[project_id]['age_max'])
+
+        gender = str(row[2])  # col 2 is gender
+        if gender not in projects[project_id][str(Constants.NIDM_GENDER)]:
+            projects[project_id][str(Constants.NIDM_GENDER)].append(gender)
+
+
+def expandNIDMAbbreviation(shortKey) -> str:
+    '''
+    Takes a shorthand identifier such as dct:description and returns the 
+    full URI http://purl.org/dc/terms/description
+
+    :param shortKey:
+    :type shortKey: str
+    :return:
+    '''
+    skey = str(shortKey)
+    match = re.search(r"^([^:]+):([^:]+)$", skey)
+    if match:
+        newkey = Constants.namespaces[match.group(1)] + match.group(2)
+    return newkey
+
+def compressForJSONResponse(data) -> dict:
+    '''
+    Takes a Dictionary and shortens any key by replacing a full URI with
+    the NIDM prefix
+
+    :param data: Data to seach for long URIs that can be replaced with prefixes
+    :return: Dictionary
+    '''
+    new_dict = {}
+
+    if isinstance(data,dict):
+        for key, value in data.items():
+            new_dict[matchPrefix(key)] = compressForJSONResponse(value)
+    else:
+        return data
+
+    return new_dict
+
+def matchPrefix(possible_URI) -> str:
+    '''
+    If the possible_URI is found in Constants.namespaces it will
+    be replaced with the prefix
+
+    :param possible_URI: URI string to look at
+    :type possible_URI: str
+    :return: Returns a
+    '''
+    for k, n in Constants.namespaces.items():
+        if possible_URI.startswith(n):
+            return "{}:{}".format(k, possible_URI.replace(n, ""))
+
+    # also check the NIDM prefix
+    if possible_URI.startswith(Constants.NIDM_URL):
+        return "{}:{}".format("nidm:", possible_URI.replace(Constants.NIDM_URL, ""))
+
+    return possible_URI

--- a/nidm/experiment/tests/test_query.py
+++ b/nidm/experiment/tests/test_query.py
@@ -1,8 +1,12 @@
 from nidm.experiment import Project, Session, AssessmentAcquisition, AssessmentObject, AcquisitionObject, Query
 from nidm.core import Constants
-from rdflib import URIRef
+from rdflib import Namespace,URIRef
 import prov.model as pm
-
+from prov.model import ProvDocument, QualifiedName
+from prov.model import Namespace as provNamespace
+import json
+import urllib.request
+from pathlib import Path
 
 def test_GetProjectMetadata():
 
@@ -75,3 +79,143 @@ def test_GetProjectInstruments():
 
     assert URIRef(Constants.NIDM + "NorthAmericanAdultReadingTest") in assessment_list
     assert URIRef(Constants.NIDM + "PositiveAndNegativeSyndromeScale") in assessment_list
+
+
+'''
+The test data file could/should have the following project meta data. Taken from
+https://raw.githubusercontent.com/incf-nidash/nidm/master/nidm/nidm-experiment/terms/nidm-experiment.owl
+  
+  - descrption
+  - fileName
+  - license
+  - source
+  - title
+  - hadNumericalValue ???
+  - BathSolution ???
+  - CellType
+  - ChannelNumber
+  - ElectrodeImpedance
+  - GroupLabel
+  - HollowElectrodeSolution
+  - hadImageContrastType
+  - hadImageUsageType
+  - NumberOfChannels
+  - AppliedFilter
+  - SolutionFlowSpeed
+  - RecordingLocation
+   
+Returns the 
+  
+'''
+def saveTestFile(file_name, data):
+    project = Project(uuid="_123_" + file_name, attributes=data)
+
+
+
+    # save a turtle file
+    with open(file_name, 'w') as f:
+        f.write(project.serializeTurtle())
+    return "nidm:_123_{}".format(file_name)
+
+def makeProjectTestFile(filename):
+    DCTYPES = Namespace("http://purl.org/dc/dcmitype/")
+
+    kwargs = {Constants.NIDM_PROJECT_NAME: "FBIRN_PhaseII", # this is the "title"
+              Constants.NIDM_PROJECT_IDENTIFIER: 9610,
+              Constants.NIDM_PROJECT_DESCRIPTION: "Test investigation",
+              Constants.NIDM_FILENAME: "testfile.ttl",
+              Constants.NIDM_PROJECT_LICENSE: "MIT Licence",
+              Constants.NIDM_PROJECT_SOURCE: "Educational Source",
+              Constants.NIDM_HAD_NUMERICAL_VALUE: "numval???",
+              Constants.NIDM_BATH_SOLUTION: "bath",
+              Constants.NIDM_CELL_TYPE: "ctype",
+              Constants.NIDM_CHANNEL_NUMBER: "5",
+              Constants.NIDM_ELECTRODE_IMPEDANCE: ".01",
+              Constants.NIDM_GROUP_LABEL: "group 123",
+              Constants.NIDM_HOLLOW_ELECTRODE_SOLUTION: "water",
+              Constants.NIDM_HAD_IMAGE_CONTRACT_TYPE: "off",
+              Constants.NIDM_HAD_IMAGE_USAGE_TYPE: "abcd",
+              Constants.NIDM_NUBMER_OF_CHANNELS: "11",
+              Constants.NIDM_APPLIED_FILTER: "on",
+              Constants.NIDM_SOLUTION_FLOW_SPEED: "2.8",
+              Constants.NIDM_RECORDING_LOCATION: "lab"
+              }
+    return saveTestFile(filename, kwargs)
+
+def makeProjectTestFile2(filename):
+    DCTYPES = Namespace("http://purl.org/dc/dcmitype/")
+
+    kwargs = {Constants.NIDM_PROJECT_NAME: "TEST B", # this is the "title"
+              Constants.NIDM_PROJECT_IDENTIFIER: 1234,
+              Constants.NIDM_PROJECT_DESCRIPTION: "More Scans",
+              Constants.NIDM_FILENAME: "testfile2.ttl",
+              Constants.NIDM_PROJECT_LICENSE: "Creative Commons",
+              Constants.NIDM_PROJECT_SOURCE: "Other",
+              Constants.NIDM_HAD_NUMERICAL_VALUE: "numval???",
+              Constants.NIDM_BATH_SOLUTION: "bath",
+              Constants.NIDM_CELL_TYPE: "ctype",
+              Constants.NIDM_CHANNEL_NUMBER: "5",
+              Constants.NIDM_ELECTRODE_IMPEDANCE: ".01",
+              Constants.NIDM_GROUP_LABEL: "group 123",
+              Constants.NIDM_HOLLOW_ELECTRODE_SOLUTION: "water",
+              Constants.NIDM_HAD_IMAGE_CONTRACT_TYPE: "off",
+              Constants.NIDM_HAD_IMAGE_USAGE_TYPE: "abcd",
+              Constants.NIDM_NUBMER_OF_CHANNELS: "11",
+              Constants.NIDM_APPLIED_FILTER: "on",
+              Constants.NIDM_SOLUTION_FLOW_SPEED: "2.8",
+              Constants.NIDM_RECORDING_LOCATION: "lab"
+              }
+    return saveTestFile(filename, kwargs)
+
+
+def test_GetProjectsMetadata():
+
+    p1 = makeProjectTestFile("testfile.ttl")
+    p2 = makeProjectTestFile2("testfile2.ttl")
+
+    if not Path('./cmu_a.nidm.ttl').is_file():
+        urllib.request.urlretrieve (
+            "https://raw.githubusercontent.com/dbkeator/simple2_NIDM_examples/master/datasets.datalad.org/abide/RawDataBIDS/CMU_a/nidm.ttl",
+            "cmu_a.nidm.ttl"
+        )
+    p3 = "nidm:_a39e09de-89da-11e8-80d8-8c8590aa91df" # from the cmu_a ttl file
+
+    json_response = Query.GetProjectsMetadata(["testfile.ttl", "testfile2.ttl", "cmu_a.nidm.ttl"])
+
+    parsed = json.loads(json_response)
+
+    assert parsed['projects'][p1][str(Constants.NIDM_PROJECT_DESCRIPTION)] == "Test investigation"
+    assert parsed['projects'][p2][str(Constants.NIDM_PROJECT_DESCRIPTION)] == "More Scans"
+    assert parsed['projects'][p3][str(Constants.NIDM_PROJECT_NAME)] == "ABIDE CMU_a Site"
+
+    # we shouldn't have the computed metadata in this result
+    assert parsed['projects'][p1].get (Query.matchPrefix(str(Constants.NIDM_NUMBER_OF_SUBJECTS)), -1) == -1
+
+
+def test_GetProjectsComputedMetadata():
+
+    p1 = makeProjectTestFile("testfile.ttl")
+    p2 = makeProjectTestFile2("testfile2.ttl")
+    if not Path('./cmu_a.nidm.ttl').is_file():
+        urllib.request.urlretrieve (
+            "https://raw.githubusercontent.com/dbkeator/simple2_NIDM_examples/master/datasets.datalad.org/abide/RawDataBIDS/CMU_a/nidm.ttl",
+            "cmu_a.nidm.ttl"
+        )
+    p3 = "nidm:_a39e09de-89da-11e8-80d8-8c8590aa91df"  # from the cmu_a ttl file
+
+    json_response = Query.GetProjectsComputedMetadata(["testfile.ttl", "testfile2.ttl", "cmu_a.nidm.ttl"])
+
+    parsed = json.loads(json_response)
+
+    assert parsed['projects'][p1][str(Constants.NIDM_PROJECT_DESCRIPTION)] == "Test investigation"
+    assert parsed['projects'][p2][str(Constants.NIDM_PROJECT_DESCRIPTION)] == "More Scans"
+    assert parsed['projects'][p3][str(Constants.NIDM_PROJECT_NAME)] == "ABIDE CMU_a Site"
+
+    assert parsed['projects'][p2][Query.matchPrefix(str(Constants.NIDM_NUMBER_OF_SUBJECTS))] == 0
+    assert parsed['projects'][p3][Query.matchPrefix(str(Constants.NIDM_NUMBER_OF_SUBJECTS))] == 14
+    assert parsed['projects'][p1][Query.matchPrefix(str(Constants.NIDM_NUMBER_OF_SUBJECTS))] == 0
+
+    assert parsed['projects'][p3]["age_min"] == 21
+    assert parsed['projects'][p3]["age_max"] == 33
+
+    assert parsed['projects'][p3][str(Constants.NIDM_GENDER)] == ['1', '2']


### PR DESCRIPTION
**Summary:**

GetProjectMetadata returns any project properties coded into a NIDM file

GetProjectComputedMetadata returns everything from GetProjectMetadata
plus some computed values: number of subjects and age range of subjects.
More computed values can be added at a later time.


**Questions / Issues:**

- The keys used in the JSON return strings use the 'prefixed' version of the predicate, for example: "dct:description" Is that how we want to index the JSON results? My only concern is that the prefixes might not be well defined at the other end of the REST API call. Should we ship a dictionary of prefixes along with the JSON? (or maybe make that a separate API call?)

- I added Constant values for a number of additional Project level predicates (if that is the right term) that were part of the NIDM spec but weren't in the Constants file already. The only place they are used are in my new test cases, so they aren't necessary. If we don't want to add them, let me know and I'll take them out. 

- The computed meta data for age min and age max **don't** use URIs. I'm not sure where to find the proper URI for this. Help would be appreciated

- The Query.py file now has a number of utility functions for things like expanding prefixed URIs and replacing long URIs with prefixed versions. Are these functions duplicating functionality elsewhere in the code that I haven't seen?  Also, the Query.py file is quite long. If these functions aren't duplicates, it would make sense to pull these functions out into their own file. Maybe something like JSONUtil.py?  Advice here appreciated.