### PR TITLE
Added 'rest' endpoints to the nidm_query.py CLI

### DIFF
--- a/nidm/experiment/Query.py
+++ b/nidm/experiment/Query.py
@@ -197,82 +197,6 @@ def GetProjectSessionsMetadata(nidm_file_list, project_uuid):
     return json.dumps(output_json)
 
 
-def GetProjectMetadata(nidm_file_list):
-    '''
-
-    :param nidm_file_list: List of one or more NIDM files to query across for list of Projects
-    :return: JSON document of all metadata for all Projects in nidm_file_list
-    '''
-
-    #SPAQRL query to get project metadata
-    #first get a list of project UUIDs
-    project_uuids = GetProjectsUUID(nidm_file_list)
-
-    #RDF graph for output data
-    results=Graph()
-    #for each project activity, get metadata
-    for project in project_uuids:
-
-        # query='''
-
-        # prefix nidm: <http://purl.org/nidash/nidm#>
-        # prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-
-        # select distinct ?uuid ?p ?o
-
-        # where {
- 	    #    ?uuid rdf:type nidm:Project ;
-	   	#    ?p  ?o .
-        # }'''
-
-
-        project_uuids = "test"
-        query= '''
-        #SELECT distinct ?p ?o
-        CONSTRUCT {
-            <%s> ?p ?o .
-        }
-        where {
-                <%s> ?p ?o .
-
-        }
-
-        ''' % (project,project)
-
-        print("my variable is named: %s" % project_uuids)
-
-        #query= '''
-
-
-        #SELECT distinct ?s ?p ?o
-
-        #where {
-        #        <%s> ?p ?o .
-        #        BIND(<%s> as ?s) .
-
-        #}
-
-        #''' % (project,project)
-        print(query)
-        df = sparql_query_nidm(nidm_file_list,query,output_file=None, return_graph=True)
-        #try:
-        #    results
-        #except NameError:
-            #results = df.to_dict()
-
-
-        #    results = df
-        #else:
-            #results.update(df.to_dict())
-        results = results + Graph().parse(df)
-
-        #now we need to iterate over the result and convert it to a better looking dictionary to ultimately be returned as JSON
-
-            #temporarily we'll simply serialize the union graph as JSON-LD...
-        return results
-
-
-
 def GetProjectInstruments(nidm_file_list, project_id):
     """
     Returns a list of unique instrument types.  For NIDM files this is rdf:type onli:assessment-instrument
@@ -403,7 +327,7 @@ def GetProjectsMetadata(nidm_file_list):
         # if field in field_whitelist:
         projects[str(project)][field] = value
 
-    return (dumps({'projects': compressForJSONResponse(projects)}))
+    return {'projects': compressForJSONResponse(projects)}
 
 
 def GetProjectsComputedMetadata(nidm_file_list):
@@ -412,11 +336,10 @@ def GetProjectsComputedMetadata(nidm_file_list):
     :return: dataframe with two columns: "project_uuid" and "project_dentifier"
     '''
 
-    meta_data = loads(GetProjectsMetadata(nidm_file_list))
+    meta_data = GetProjectsMetadata(nidm_file_list)
     ExtractProjectSummary(meta_data, nidm_file_list)
-    compressed_meta_data = compressForJSONResponse(meta_data)
 
-    return (dumps(compressed_meta_data))
+    return compressForJSONResponse(meta_data)
 
 
 def ExtractProjectSummary(meta_data, nidm_file_list):

--- a/nidm/experiment/tools/nidm_query.py
+++ b/nidm/experiment/tools/nidm_query.py
@@ -40,6 +40,8 @@ import csv
 from nidm.experiment.Query import sparql_query_nidm, GetParticipantIDs,GetProjectInstruments,GetProjectsUUID,GetInstrumentVariables
 import click
 from nidm.experiment.tools.click_base import cli
+from nidm.experiment.tools.rest import restParser
+from json import dumps, loads
 
 
 @cli.command()
@@ -55,7 +57,12 @@ from nidm.experiment.tools.click_base import cli
               help="Parameter, if set, query will return list of onli:assessment-instrument: variables")
 @click.option("--output_file", "-o", required=False,
               help="Optional output file (CSV) to store results of query")
-def query(nidm_file_list, query_file, output_file, get_participants,get_instruments,get_instrument_vars):
+@click.option("--uri", "-u", required=False,
+              help="A REST API URI query")
+@click.option("-j/-no_j", required=False, default=False,
+              help="Return result of a uri query as JSON")
+@click.option('-v', '--verbosity', required=False, help="Verbosity level 0-5, 0 is default", default="0")
+def query(nidm_file_list, query_file, output_file, get_participants, get_instruments, get_instrument_vars, uri, j, verbosity):
 
     #query result list
     results = []
@@ -103,6 +110,19 @@ def query(nidm_file_list, query_file, output_file, get_participants,get_instrume
             df.to_csv(output_file)
         else:
             print(df)
+    elif uri:
+        df = restParser(nidm_file_list.split(','), uri, int(verbosity))
+        if j:
+            print (dumps(df))
+        else:
+            if type(df) == list:
+                for x in df:
+                    print (x)
+            elif type(df) == dict:
+                for k in df.keys():
+                    print (str(k) + ' ' + str(df[k]))
+            else:
+                print (df)
     else:
         #read query from text fiile
         with open(query_file, 'r') as fp:

--- a/nidm/experiment/tools/rest.py
+++ b/nidm/experiment/tools/rest.py
@@ -1,0 +1,45 @@
+from nidm.experiment import Project, Session, AssessmentAcquisition, AssessmentObject, Acquisition, AcquisitionObject, Query
+from nidm.core import Constants
+import json
+import re
+from urllib import parse
+import pprint
+
+def restParser (nidm_files, command, verbosity_level = 0):
+
+    restLog("parsing command "+ command, 1, verbosity_level)
+    restLog("Files to read:" + str(nidm_files), 1, verbosity_level)
+
+    result = []
+    if re.match(r"^/?projects/?$", command):
+        restLog("Returning all projects", 2, verbosity_level)
+        projects = Query.GetProjectsUUID(nidm_files)
+        for uuid in projects:
+            result.append( Query.matchPrefix(str(uuid)))
+
+    elif re.match(r"^/?projects/[^/]+$", command):
+        restLog("Returing metadata ", 2, verbosity_level)
+        match = re.match(r"^/?projects/([^/]+)$", command)
+        id = parse.unquote ( str( match.group(1) ) )
+        restLog("computing metadata", 5, verbosity_level)
+        projects = Query.GetProjectsComputedMetadata(nidm_files)
+        for pid in projects['projects'].keys():
+            restLog("comparng " + str(pid) + " with " + str(id), 5, verbosity_level)
+            if pid == id:
+                result = projects['projects'][pid]
+    return result
+
+
+def restLog (message, verbosity_of_message, verbosity_level):
+    if verbosity_of_message <= verbosity_level:
+        print (message)
+
+def formatResults (result, format, stream):
+    pp = pprint.PrettyPrinter(stream=stream)
+    if format == 'text':
+        if isinstance(result, list):
+            print(*result, sep='\n', file=stream)
+        else:
+            pp.pprint(result)
+    else:
+        print(json.dumps(result, indent=2, separators=(',', ';')), file=stream)

--- a/nidm/experiment/tools/tests/test_rest.py
+++ b/nidm/experiment/tools/tests/test_rest.py
@@ -1,0 +1,68 @@
+import pytest
+from nidm.experiment import Project, Session, AssessmentAcquisition, AssessmentObject, Acquisition, AcquisitionObject, Query
+from nidm.core import Constants
+from nidm.experiment.tools.rest import restParser
+from json import loads
+import pprint
+import os
+from urllib import parse
+
+from ..nidm_query import query
+
+@pytest.mark.skip
+def test_uri_project():
+
+    kwargs={Constants.NIDM_PROJECT_NAME:"FBIRN_PhaseII",Constants.NIDM_PROJECT_IDENTIFIER:9610,Constants.NIDM_PROJECT_DESCRIPTION:"Test investigation"}
+    project = Project(uuid="_123456",attributes=kwargs)
+    #save a turtle file
+    with open("uritest.ttl",'w') as f:
+        f.write(project.serializeTurtle())
+
+    kwargs={Constants.NIDM_PROJECT_NAME:"FBIRN_PhaseIII",Constants.NIDM_PROJECT_IDENTIFIER:1200,Constants.NIDM_PROJECT_DESCRIPTION:"Test investigation2"}
+    project = Project(uuid="_654321",attributes=kwargs)
+    #save a turtle file
+    with open("uritest2.ttl",'w') as f:
+        f.write(project.serializeTurtle())
+
+    result = restParser(['uritest.ttl', 'uritest2.ttl'], '/projects')
+
+    print (result)
+
+    project_uuids = []
+
+    for uuid in result:
+        project_uuids.append(uuid)
+
+    assert type(result) == list
+    assert len(project_uuids) == 2
+    assert str(Constants.NIDM_URL) + "_123456" in project_uuids
+    assert str(Constants.NIDM_URL) + "_654321" in project_uuids
+
+    os.remove("uritest.ttl")
+    os.remove("uritest2.ttl")
+
+
+def test_uri_project_id():
+
+    kwargs={Constants.NIDM_PROJECT_NAME:"FBIRN_PhaseII",Constants.NIDM_PROJECT_IDENTIFIER:9610,Constants.NIDM_PROJECT_DESCRIPTION:"1234356 Test investigation"}
+    project = Project(uuid="_123456",attributes=kwargs)
+    #save a turtle file
+    with open("uri2test.ttl",'w') as f:
+        f.write(project.serializeTurtle())
+
+    kwargs={Constants.NIDM_PROJECT_NAME:"FBIRN_PhaseIII",Constants.NIDM_PROJECT_IDENTIFIER:1200,Constants.NIDM_PROJECT_DESCRIPTION:"Test investigation2"}
+    project = Project(uuid="_654321",attributes=kwargs)
+    #save a turtle file
+    with open("uri2test2.ttl",'w') as f:
+        f.write(project.serializeTurtle())
+
+    result = restParser(['uri2test.ttl', 'uri2test2.ttl'], '/projects/nidm:_123456')
+
+    pp = pprint.PrettyPrinter()
+    pp.pprint (result)
+
+    assert type(result) == dict
+    assert result["dct:description"] == "1234356 Test investigation"
+
+    # os.remove("uri2test.ttl")
+    # os.remove("uri2test2.ttl")


### PR DESCRIPTION
Added /projects and /projects/#PID routers
Show all project meta data when project details CLI rest call is made
Added non-json output for lists and dictionaries in the CLI
Added verbose option to nidm_query.py