### PR TITLE
changed nidm entry to pynidm to avoid collisions with NIDM-R libraries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,17 +38,16 @@ Query
 
 .. code-block:: bash
 
-	$ nidm query [OPTIONS]
+	$ pynidm query [OPTIONS]
 
 Options:
-
--nl, --nidm_file_list    A comma separated list of NIDM files with full path [required]
-
--q, --query_file     Text file containing a SPARQL query to execute [required]
-
--o, --output_file     Optional output file (CSV) to store results of the query
-
---help    Show this message and exit
+  -nl, --nidm_file_list TEXT  A comma separated list of NIDM files with full
+                              path  [required]
+  -q, --query_file PATH       Text file containing a SPARQL query to execute
+                              [required]
+  -o, --output_file TEXT      Optional output file (CSV) to store results of
+                              query
+  --help                      Show this message and exit.
 
 
 BIDS MRI Conversion to NIDM
@@ -56,111 +55,110 @@ BIDS MRI Conversion to NIDM
 
 This program will convert a BIDS MRI dataset to a NIDM-Experiment RDF document.  It will parse phenotype information and simply store variables/values and link to the associated json data dictionary file.
 
+While we're migrating to using 'click', this tools is still buried in the tools directory of the repo
+
 .. code-block:: bash
 
-    $ BIDSMRI2NIDM -d [ROOT BIDS DIRECT] -bidsignore
- 
+    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
+
 Example 1:No variable->term mapping, simple BIDS dataset conversion which will add nidm.ttl file to BIDS dataset and .bidsignore file:
 
 .. code-block:: bash
 
-    $ BIDSMRI2NIDM -d [root directory of BIDS dataset] -o [PATH/nidm.ttl]
- 
-Example 2:No variable->term mapping, simple BIDS dataset conversion but storing nidm file somewhere else: 
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -o [PATH/nidm.ttl]
+
+Example 2:No variable->term mapping, simple BIDS dataset conversion but storing nidm file somewhere else:
 
 .. code-block:: bash
 
-    $ BIDSMRI2NIDM -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -bidsignore
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -bidsignore
 
-Example 3:BIDS conversion with variable->term mappings, no existing mappings available, uses Interlex for terms and for defining terms you can't find in Interlex (note, for now these two need to be used together)!  To get an Interlex API key you visit [SciCrunch](http://scicrunch.org), register for an account, then click on "MyAccount" and "API Keys" to add a new API key for your account.  Use this API Key for the -ilxkey parameter below.  This example  adds a nidm.ttl file BIDS dataset and .bidsignore file and it will by default create you a JSON mapping file which contains the variable->term mappings you defined during the interactive, iterative activity of using this tool to map your variables to terms.  The default JSON mapping file will be called nidm_json_map.json but you can also specify this explictly using the -json_map parameter (see Example 5 below): 
-
-.. code-block:: bash
-
-    $ BIDSMRI2NIDM -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -owl -bidsignore
-Example 4: (FULL MONTY): BIDS conversion with variable->term mappings, uses JSON mapping file first then uses Interlex + NIDM OWL file for terms, adds nidm.ttl file BIDS dataset and .bidsignore file: 
+Example 3:BIDS conversion with variable->term mappings, no existing mappings available, uses Interlex for terms. To get an Interlex API key you visit [SciCrunch](http://scicrunch.org), register for an account, then click on "MyAccount" and "API Keys" to add a new API key for your account.  Use this API Key for the -ilxkey parameter below.  This example  adds a nidm.ttl file BIDS dataset and .bidsignore file and it will by default create you a JSON mapping file which contains the variable->term mappings you defined during the interactive, iterative activity of using this tool to map your variables to terms.  A JSON mapping file be stored for participants.tsv called participants.json and the nidm.ttl file will be stored at the root of the BIDS directory (but you can also specify this explictly using the -json_map parameter (see Example 4 below)):
 
 .. code-block:: bash
 
-    $ BIDSMRI2NIDM -d [root directory of BIDS dataset] -json_map [Your JSON file] -ilxkey [Your Interlex key] -bidsignore
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -json_map [Your JSON file] -ilxkey [Your Interlex key] -bidsignore
 
-	 json mapping file has entries for each variable with mappings to formal terms.  Example:  
+Example 5 BIDS conversion with variable->term mappings, uses JSON mapping file first then uses Interlex, adds nidm.ttl file to root of BIDS dataset and adds to .bidsignore file:
 
-    	 { 
+	 json mapping file has entries for each variable with mappings to formal terms.  Example:
 
-    		 "site": { 
+    	 {
 
-			 "definition": "Number assigned to site", 
+    		 "site": {
 
-			 "label": "site_id (UC Provider Care)", 
+			 "definition": "Number assigned to site",
 
-			 "url": "http://uri.interlex.org/NDA/uris/datadictionary/elements/2031448" 
+			 "label": "site_id (UC Provider Care)",
 
-			 }, 
+			 "url": "http://uri.interlex.org/NDA/uris/datadictionary/elements/2031448"
 
-			 "gender": { 
+			 },
 
-			 "definition": "ndar:gender", 
+			 "gender": {
 
-			 "label": "ndar:gender", 
+			 "definition": "ndar:gender",
 
-			 "url": "https://ndar.nih.gov/api/datadictionary/v2/dataelement/gender" 
+			 "label": "ndar:gender",
 
-			 } 
+			 "url": "https://ndar.nih.gov/api/datadictionary/v2/dataelement/gender"
+
+			 }
 
     	 }
-		 
-optional arguments: 
--h, --help            show this help message and exit
-	
--d DIRECTORY          Path to BIDS dataset directory
 
--jsonld, --jsonld     If flag set, output is json-ld not TURTLE
-	
--png, --png           If flag set, tool will output PNG file of NIDM graph
-	
--bidsignore, --bidsignore      If flag set, tool will add NIDM-related files to .bidsignore file
-						  
--o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default
+optional arguments:
+	-h, --help            show this help message and exit
 
-map variables to terms arguments:
+	-d DIRECTORY          Path to BIDS dataset directory
 
--json_map, --json_map       Optional user-suppled JSON file containing variable-term mappings
-						  
--ilxkey, --ilxkey     Interlex/SciCrunch API key to use for query
+	-jsonld, --jsonld     If flag set, output is json-ld not TURTLE
 
-CSV File to NIDM and BIDS JSON Sidecar Conversion
--------------------------------------------------
+	-png, --png           If flag set, tool will output PNG file of NIDM graph
+
+	-bidsignore, --bidsignore
+
+	                      If flag set, tool will add NIDM-related files to .bidsignore file
+
+	-o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default
+
+	map variables to terms arguments:
+
+	-json_map JSON_MAP, --json_map JSON_MAP
+
+	                      Optional user-suppled JSON file containing variable-term mappings.
+
+	-ilxkey KEY, --ilxkey KEY
+
+	                      Interlex/SciCrunch API key to use for query
+
+
+CSV File to NIDM Conversion
+---------------------------
 This program will load in a CSV file and iterate over the header variable
 names performing an elastic search of https://scicrunch.org/ for NIDM-ReproNim
 tagged terms that fuzzy match the variable names. The user will then
 interactively pick a term to associate with the variable name. The resulting
 annotated CSV data will then be written to a NIDM data file.
 
-**While we're migrating to using 'click', this tool doesn't yet support "nidm csv2nidm" so once you've installed PyNIDM toolbox then type "csv2nidm" in a terminal window and things should work
+While we're migrating to using 'click', this tools is still buried in the tools directory of the repo
 
 .. code-block:: bash
 
     $ csv2nidm  [OPTIONS]
 
 optional arguments:
+  -h, --help            show this help message and exit
 
--h, --help            show this help message and exit
+  -csv CSV_FILE         Path to CSV file to convert
 
--csv     Path to CSV file to convert
-  
--ilxkey     Interlex/SciCrunch API key to use for query
-  
--json_map     User-suppled JSON file containing variable-term mappings.
-  
--nidm     Optional NIDM file to add CSV->NIDM converted graph to an existing NIDM file
+  -ilxkey KEY           Interlex/SciCrunch API key to use for query
 
--json_map, --json_map       Optional user-suppled JSON file containing variable-term mappings
-						  
--ilxkey, --ilxkey     Interlex/SciCrunch API key to use for query
+  -json_map JSON_MAP    User-suppled JSON file containing variable-term mappings.
 
--png      Optional flag, when set a PNG image file of RDF graph will be produced
- 
--out     Filename to save NIDM file
+  -nidm NIDM_FILE       Optional NIDM file to add CSV->NIDM converted graph to
+
+  -out OUTPUT_FILE      Filename to save NIDM file
 
 
 .. |Build Status| image:: https://travis-ci.org/incf-nidash/PyNIDM.svg?branch=master

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -77,32 +77,27 @@ While we're migrating to using 'click', this tools is still buried in the tools 
 
 .. code-block:: bash
 
-    $ ./nidm/experiment/tools/BIDSMRI2NIDM.py -d [ROOT BIDS DIRECT] -bidsignore
+    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
  
 Example 1:No variable->term mapping, simple BIDS dataset conversion which will add nidm.ttl file to BIDS dataset and .bidsignore file:
 
 .. code-block:: bash
 
-    $ ./nidm/experiment/tools/BIDSMRI2NIDM.py -d [root directory of BIDS dataset] -o [PATH/nidm.ttl]
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -o [PATH/nidm.ttl]
  
 Example 2:No variable->term mapping, simple BIDS dataset conversion but storing nidm file somewhere else: 
 
 .. code-block:: bash
 
-    $ ./nidm/experiment/tools/BIDSMRI2NIDM.py -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -github [username token] -bidsignore
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -bidsignore
 
-Example 3:BIDS conversion with variable->term mappings, no existing mappings available, uses Interlex for terms and github for defining terms you can't find in Interlex (note, for now these two need to be used together)!  To get an Interlex API key you visit [SciCrunch](http://scicrunch.org), register for an account, then click on "MyAccount" and "API Keys" to add a new API key for your account.  Use this API Key for the -ilxkey parameter below.  This example  adds a nidm.ttl file BIDS dataset and .bidsignore file and it will by default create you a JSON mapping file which contains the variable->term mappings you defined during the interactive, iterative activity of using this tool to map your variables to terms.  The default JSON mapping file will be called nidm_json_map.json but you can also specify this explictly using the -json_map parameter (see Example 5 below): 
-
-.. code-block:: bash
-
-    $ ./nidm/experiment/tools/BIDSMRI2NIDM.py -d [root directory of BIDS dataset] -ilxkey [Your Interlex key] -github [username token] -owl -bidsignore
-Example 4: BIDS conversion with variable->term mappings, no existing mappings available, uses Interlex + NIDM OWL file for terms and github, adds nidm.ttl file BIDS dataset and .bidsignore file: 
+Example 3:BIDS conversion with variable->term mappings, no existing mappings available, uses Interlex for terms. To get an Interlex API key you visit [SciCrunch](http://scicrunch.org), register for an account, then click on "MyAccount" and "API Keys" to add a new API key for your account.  Use this API Key for the -ilxkey parameter below.  This example  adds a nidm.ttl file BIDS dataset and .bidsignore file and it will by default create you a JSON mapping file which contains the variable->term mappings you defined during the interactive, iterative activity of using this tool to map your variables to terms.  A JSON mapping file be stored for participants.tsv called participants.json and the nidm.ttl file will be stored at the root of the BIDS directory (but you can also specify this explictly using the -json_map parameter (see Example 4 below)):
 
 .. code-block:: bash
 
-    $ ./nidm/experiment/tools/BIDSMRI2NIDM.py -d [root directory of BIDS dataset] -json_map [Your JSON file] -ilxkey [Your Interlex key] -github [username token] -owl -bidsignore
+    $ bidsmri2nidm -d [root directory of BIDS dataset] -json_map [Your JSON file] -ilxkey [Your Interlex key] -bidsignore
 
-Example 5 (FULL MONTY): BIDS conversion with variable->term mappings, uses JSON mapping file first then uses Interlex + NIDM OWL file for terms and github, adds nidm.ttl file BIDS dataset and .bidsignore file: 
+Example 5 BIDS conversion with variable->term mappings, uses JSON mapping file first then uses Interlex, adds nidm.ttl file to root of BIDS dataset and adds to .bidsignore file:
 
 	 json mapping file has entries for each variable with mappings to formal terms.  Example:  
 
@@ -155,14 +150,6 @@ optional arguments:
 	
 	                      Interlex/SciCrunch API key to use for query
 						  
-	-github [GITHUB [GITHUB ...]], --github [GITHUB [GITHUB ...]]
-	
-	                      Use -github flag with list username token(or pw) for storing locally-defined terms in a
-	                      nidm-local-terms repository in GitHub.  If user doesn''t supply a token then user will be prompted for username/password.
-                        
-	                      Example: -github username token
-						  
-	-owl                  Optional flag to query nidm-experiment OWL files
 
 CSV File to NIDM Conversion
 ---------------------------
@@ -176,7 +163,7 @@ While we're migrating to using 'click', this tools is still buried in the tools 
 
 .. code-block:: bash
 
-    $ ./nidm/experiment/tools/CSV2NIDM.py  [OPTIONS]
+    $ csv2nidm  [OPTIONS]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -188,16 +175,6 @@ optional arguments:
   -json_map JSON_MAP    User-suppled JSON file containing variable-term mappings.
   
   -nidm NIDM_FILE       Optional NIDM file to add CSV->NIDM converted graph to
-  
-  -github [GITHUB [GITHUB ...]]
-                        Use -github flag with username token(or pw) for
-                        storing locally-defined terms in a "nidm-local-terms"
-                        repository in GitHub. If user doesnt supply a token
-                        then user will be prompted for username/password.
-                        Example: -github username token
-						
-  -owl                  Optionally searches NIDM OWL files...internet
-                        connection required
 						
   -out OUTPUT_FILE      Filename to save NIDM file
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 PACKAGES = find_packages()
 
-# Get version and release info, which is all stored in ndim/version.py
+# Get version and release info, which is all stored in nidm/version.py
 ver_file = os.path.join('nidm', 'version.py')
 with open(ver_file) as f:
     exec(f.read())
@@ -25,7 +25,7 @@ opts = dict(name=NAME,
             #requires=INSTALL_REQUIRES,
             entry_points='''
                [console_scripts]
-               nidm=nidm.experiment.tools.click_main:cli
+               pynidm=nidm.experiment.tools.click_main:cli
             '''
 )
 


### PR DESCRIPTION
There is a collision with NIDM-R libraries when entry point for PyNIDM was 'nidm' so for now I've changed it to 'pynidm'.  For example, use  'pynidm query' instead of previous 'nidm query'.  At some point we'll need to merge NIDM-R code into PyNIDM library when @cmaumet is back.  

@khelm this should fix you problems having both installed in the same python virtual environment.  Just git pull and do a pip install -e .

