### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,8 @@ RUN apt-get update &&  \
     apt-get install -y git python3 graphviz python3-pip ssh mercurial python-setuptools
 
 RUN python3 -m pip install --upgrade pip && \
-    pip3 install rdflib requests fuzzywuzzy pygithub pybids duecredit setuptools \
-                 python-Levenshtein pytest graphviz prov pydot validators ontquery \
+    pip3 install rdflib requests rapidfuzz pygithub pybids duecredit setuptools \
+                 pytest graphviz prov pydot validators ontquery \
                  click rdflib-jsonld pyld pytest-cov tabulate
 
 WORKDIR /opt

--- a/nidm/experiment/Utils.py
+++ b/nidm/experiment/Utils.py
@@ -12,7 +12,7 @@ import prov.model as pm
 from prov.model import QualifiedName
 from prov.model import Namespace as provNamespace
 import requests
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 import json
 from github import Github, GithubException
 import getpass

--- a/nidm/version.py
+++ b/nidm/version.py
@@ -55,7 +55,7 @@ MAJOR = _version_major
 MINOR = _version_minor
 MICRO = _version_micro
 VERSION = __version__
-INSTALL_REQUIRES = ["prov", "graphviz", "pydotplus", "pydot", "validators", "requests", "fuzzywuzzy", "pygithub",
+INSTALL_REQUIRES = ["prov", "graphviz", "pydotplus", "pydot", "validators", "requests", "rapidfuzz", "pygithub",
                     "pandas", "pybids", "duecredit", "pytest", "graphviz", "click", "neurdflib-jsonld",
                     "pyld", "neurdflib", "datalad", "ontquery>=0.2.2", "orthauth>=0.0.8","tabulate"]
 SCRIPTS = ["bin/nidm_query", "bin/bidsmri2nidm", "bin/csv2nidm","bin/nidm_utils"]


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.