### PR TITLE
Adding support for matching synonyms when doing a filter and field match

### DIFF
--- a/nidm/experiment/tools/tests/test_rest.py
+++ b/nidm/experiment/tools/tests/test_rest.py
@@ -386,6 +386,26 @@ def test_ExtremeFilters():
     assert len(details['data_elements']['uuid']) > 0
 
 
+def test_Filter_Flexibility():
+    restParser = RestParser(output_format=RestParser.OBJECT_FORMAT)
+    if cmu_test_project_uuid:
+        project = cmu_test_project_uuid
+    else:
+        projects  = restParser.run(BRAIN_VOL_FILES, '/projects')
+        project = projects[0]
+
+    synonyms = Query.GetDatatypeSynonyms(tuple(BRAIN_VOL_FILES),project, 'ADOS_MODULE')
+    real_synonyms = [x for x in synonyms if len(x) > 1]
+
+    assert len(real_synonyms) > 1
+
+    for syn in real_synonyms:
+        if ' ' in syn:
+            continue
+        details = restParser.run(BRAIN_VOL_FILES, '/projects/{}?filter=instruments.{} gt 2'.format(project, syn))
+        assert len(details['subjects']['uuid']) > 0
+        assert len(details['data_elements']['uuid']) > 0
+
 
 def test_OpenGraph():
 

--- a/profiler.py
+++ b/profiler.py
@@ -3,7 +3,7 @@ import cProfile
 
 def go():
     restParser = RestParser(output_format=RestParser.OBJECT_FORMAT, verbosity_level=5)
-    result = restParser.run(["ttl/cmu_a.nidm.ttl"], "projects/dad0f09c-49ec-11ea-9fd8-003ee1ce9545?fields=fs_000003")
+    result = restParser.run(["ttl/caltech.ttl"], '/projects/e059fc5e-67aa-11ea-84b4-003ee1ce9545/subjects?filter=instruments.ADOS_MODULE gt 2')
     print (result)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch will look at a few different strings found in the data element definition when comparing for filters and field requests in the REST API. This means you can use things like "AGE_AT_SCAN", or the UUID for the age data element, or the isAbout URI when building the filter/fields parameters.