### PR TITLE
[FIX] include pyontutils by installing services with ontquery

### DIFF
--- a/nidm/version.py
+++ b/nidm/version.py
@@ -57,5 +57,5 @@ MICRO = _version_micro
 VERSION = __version__
 INSTALL_REQUIRES = ["prov", "graphviz", "pydotplus", "pydot", "validators", "requests", "rapidfuzz", "pygithub",
                     "pandas", "pybids>=0.12.0", "duecredit", "pytest", "graphviz", "click", "rdflib-jsonld",
-                    "pyld", "rdflib", "datalad", "ontquery>=0.2.3", "orthauth>=0.0.12","tabulate", "joblib", "cognitiveatlas", "numpy", "etelemetry","click-option-group"]
+                    "pyld", "rdflib", "datalad", "ontquery[services]>=0.2.3", "orthauth>=0.0.12","tabulate", "joblib", "cognitiveatlas", "numpy", "etelemetry","click-option-group"]
 SCRIPTS = ["bin/nidm_query", "bin/bidsmri2nidm", "bin/csv2nidm","bin/nidm_utils"]


### PR DESCRIPTION
pyontutils is not installed by ontquery, but pyontutils is required for [InterlexRemote](https://github.com/incf-nidash/PyNIDM/blob/2f48a8b6b7f72cd01ae65cc88f454c35cb68d587/nidm/experiment/Utils.py#L574) to work on our JupyterHub. (see ABCD-Repronim/reprohub#1). 
This pull request installs ontquery with pyontutils by installing the services extra.