### PR TITLE
Adding support for Blazegraph

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.6"
+services:
+  blazegraph:
+    build:
+      context: .
+      dockerfile: Dockerfile-blazegraph
+    ports:
+      - "192.168.56.101:9999:9999"

--- a/docker/rest-blaze.py
+++ b/docker/rest-blaze.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+
+from flask import Flask, request
+from flask_restful import Resource, Api
+import glob
+from nidm.experiment.tools.rest import RestParser
+from flask_cors import CORS
+import simplejson
+import os
+
+def getTTLFiles():
+    files = []
+    for filename in glob.glob('/opt/project/ttl/**/*.ttl', recursive=True):
+        files.append(filename)
+    return files
+
+class NIDMRest(Resource):
+    def get(self, all):
+
+        query_bits = []
+        for a in request.args.keys():
+            query_bits.append("{}={}".format(a, request.args.get(a)))
+        query = "&".join(query_bits)
+
+        files = getTTLFiles()
+        if len(files) == 0:
+            return ({'error' : 'No NIDM files found. You may need to add NIDM ttl files to ~/PyNIDM/ttl'})
+        restParser = RestParser(output_format=RestParser.OBJECT_FORMAT, verbosity_level=5)
+
+        json_str = simplejson.dumps(restParser.run(files, "{}?{}".format(all, query)), indent=2)
+        response = app.response_class(response=json_str, status=200, mimetype='application/json')
+
+        return response
+
+class Instructions(Resource):
+    def get(self):
+
+        return ({'message' : 'You probably want to start at {}projects  See instructions at PyNIDM/docker/README.md for details on the API and loading data.'.format(request.url_root)})
+
+
+
+app = Flask(__name__)
+CORS(app)
+api = Api(app)
+api.add_resource(Instructions, '/')
+api.add_resource(NIDMRest, '/<path:all>')
+
+if __name__ == '__main__':
+
+    os.system('java -server -Xmx512mb -jar /opt/blazegraph.jar')
+    app.run(debug=True, host='0.0.0.0')

--- a/nidm/experiment/Navigate.py
+++ b/nidm/experiment/Navigate.py
@@ -13,8 +13,8 @@ isPartOf = Constants.DCT['isPartOf']
 ValueType = collections.namedtuple('ValueType',
                                    ['value', 'label', 'datumType', 'hasUnit', 'isAbout', 'measureOf', 'hasLaterality', 'dataElement', 'description', 'subject', 'project'])
 ActivityData = collections.namedtuple('ActivityData', ['category', 'uuid', 'data'])
-QUERY_CACHE_SIZE=64
-BIG_CACHE_SIZE=256
+QUERY_CACHE_SIZE=0
+BIG_CACHE_SIZE=0
 
 def makeValueType(value=None, label=None, datumType=None, hasUnit=None, isAbout=None, measureOf=None, hasLaterality=None, dataElement=None, description=None, subject=None, project=None):
     return ValueType(str(value), str(label), str(datumType), str(hasUnit), str(isAbout), str(measureOf), str(hasLaterality), str(dataElement), str(description), str(subject), str(project))

--- a/nidm/experiment/Query.py
+++ b/nidm/experiment/Query.py
@@ -37,10 +37,13 @@ from nidm.core import Constants
 import nidm.experiment.CDE
 import re
 import tempfile
-from os import path
+from os import path, environ
 import functools
 import hashlib
 import pickle
+import requests
+import json
+
 
 from joblib import Memory
 memory = Memory(tempfile.gettempdir(), verbose=0 )
@@ -63,6 +66,28 @@ def sparql_query_nidm(nidm_file_list,query, output_file=None, return_graph=False
     :param return_graph: WIP - not working right now but for some queries we prefer to return a graph instead of a dataframe
     :return: dataframe | graph depending on return_graph parameter
     '''
+
+
+
+    if 'BLAZEGRAPH_URL' in environ.keys():
+        try:
+            # first make sure all files are loaded into blazegraph
+            for nidm_file in nidm_file_list:
+                OpenGraph(nidm_file)
+            logging.debug("Sending sparql to blazegraph: %s", query )
+            r2 = requests.post(url=environ['BLAZEGRAPH_URL'], params={'query': query}, headers={'Accept': 'application/sparql-results+json'})
+            content = json.loads( r2.content )
+            columns = {}
+            for key in content["head"]['vars']:
+                columns[key] = [x[key]['value'] for x in content['results']['bindings']]
+            df = pd.DataFrame(data=columns)
+            if (output_file is not None):
+                df.to_csv(output_file)
+            return df
+
+        except Exception as e:
+            print("Exception while communicating with blazegraph at {}: {}".format(environ['BLAZEGRAPH_URL'],e))
+
 
     #query result list
     results = []
@@ -143,9 +168,9 @@ def GetProjectsUUID(nidm_file_list,output_file=None):
 
         }
     '''
-    df = sparql_query_nidm(nidm_file_list,query, output_file=output_file)
+    df = sparql_query_nidm(nidm_file_list, query, output_file=output_file)
 
-    return df['uuid'].tolist()
+    return df['uuid'] if type(df['uuid']) == list else df['uuid'].tolist()
 
 def testprojectmeta(nidm_file_list):
 
@@ -317,7 +342,6 @@ def GetParticipantIDs(nidm_file_list,output_file=None):
         PREFIX sio: <http://semanticscience.org/ontology/sio.owl#>
         PREFIX ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/>
         PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-        PREFIX prov:<http://www.w3.org/ns/prov#>
 
         SELECT DISTINCT ?uuid ?ID
         WHERE {
@@ -1097,9 +1121,22 @@ def OpenGraph(file):
     :param file: filename
     :return: Graph
     '''
+
     # if someone passed me a RDF graph rather than a file, just send it back
     if isinstance(file, rdflib.graph.Graph):
         return file
+
+
+    # If we have a Blazegraph instance, load the data then do the rest
+    if 'BLAZEGRAPH_URL' in environ.keys():
+        try:
+            f = open(file)
+            data = f.read()
+            logging.debug("Sending {} to blazegraph".format(file))
+            r = requests.post(url=environ['BLAZEGRAPH_URL'], data=data, headers={'Content-type': 'application/x-turtle'})
+        except Exception as e:
+            logging.error("Exception {} loading {} into Blazegraph.".format(e, file))
+
 
     BLOCKSIZE = 65536
     hasher = hashlib.md5()

--- a/nidm/experiment/tools/nidm_query.py
+++ b/nidm/experiment/tools/nidm_query.py
@@ -74,9 +74,11 @@ from json import dumps, loads
               help="Optional output file (CSV) to store results of query")
 @click.option("-j/-no_j", required=False, default=False,
               help="Return result of a uri query as JSON")
+@click.option("--blaze", "-bg", required=False,
+              help="Base URL for Blazegraph. Ex: http://172.19.0.2:9999/blazegraph/sparql")
 @click.option('-v', '--verbosity', required=False, help="Verbosity level 0-5, 0 is default", default="0")
 
-def query(nidm_file_list, cde_file_list, query_file, output_file, get_participants, get_instruments, get_instrument_vars, get_dataelements, get_brainvols,get_dataelements_brainvols, get_fields, uri, j, verbosity):
+def query(nidm_file_list, cde_file_list, query_file, output_file, get_participants, get_instruments, get_instrument_vars, get_dataelements, get_brainvols,get_dataelements_brainvols, get_fields, uri, blaze, j, verbosity):
     """
     This function provides query support for NIDM graphs.
     """
@@ -86,6 +88,10 @@ def query(nidm_file_list, cde_file_list, query_file, output_file, get_participan
     # if there is a CDE file list, seed the CDE cache
     if cde_file_list:
         getCDEs(cde_file_list.split(","))
+
+    if blaze:
+        os.environ["BLAZEGRAPH_URL"] = blaze
+        print("setting BLAZEGRAPH_URL to {}".format(blaze))
 
     if get_participants:
         df = GetParticipantIDs(nidm_file_list.split(','),output_file=output_file)

--- a/nidm/experiment/tools/rest.py
+++ b/nidm/experiment/tools/rest.py
@@ -5,6 +5,7 @@ from nidm.core import Constants
 import json
 import re
 from urllib import parse
+import logging
 import pprint
 import os
 from tempfile import gettempdir
@@ -351,7 +352,7 @@ class RestParser:
         projects = Query.GetProjectsUUID(self.nidm_files)
         for uuid in projects:
             result.append(str(uuid).replace(Constants.NIIRI, ""))
-        return self.format(result)
+        return self.format(result, ["UUID"])
 
     def ExpandProjectMetaData(self, meta_data):
         """
@@ -390,8 +391,8 @@ class RestParser:
 
             print(Query.GetParticipantUUIDsForProject(self.nidm_files, project_uuid))
 
-            project['age_max'] = max(ages)
-            project['age_min'] = min(ages)
+            project['age_max'] = max(ages) if len(ages) > 0 else 0
+            project['age_min'] = min(ages) if len(ages) > 0 else 0
             project[Query.matchPrefix(str(Constants.NIDM_NUMBER_OF_SUBJECTS))] = len((Query.GetParticipantUUIDsForProject(self.nidm_files, project_uuid))['uuid'])
             project[str(Constants.NIDM_GENDER)] = list(genders)
             project[str(Constants.NIDM_HANDEDNESS)] = list(hands)
@@ -675,7 +676,8 @@ class RestParser:
                 self.query['fields'] = []
 
             return self.route()
-        except ValueError:
+        except ValueError as ve:
+            logging.error("Exception: {}".format(ve))
             return (self.format({"error": "One of the supplied field terms was not found."}))
 
 

--- a/nidm/experiment/tools/tests/test_rest_subjects.py
+++ b/nidm/experiment/tools/tests/test_rest_subjects.py
@@ -42,7 +42,12 @@ def setup():
 
     restParser = RestParser(output_format=RestParser.OBJECT_FORMAT)
     projects = restParser.run(BRAIN_VOL_FILES, '/projects')
-    cmu_test_project_uuid = projects[0]
+    for p in projects:
+        proj_info = restParser.run(BRAIN_VOL_FILES, '/projects/{}'.format(p))
+        if 'dctypes:title' in proj_info.keys() and proj_info['dctypes:title'] == 'ABIDE CMU_a Site':
+            cmu_test_project_uuid = p
+            break
+
     subjects = restParser.run(BRAIN_VOL_FILES, '/projects/{}/subjects'.format(cmu_test_project_uuid))
     cmu_test_subject_uuid = subjects['uuid'][0]
 
@@ -53,9 +58,12 @@ def setup():
             "ds000168.nidm.ttl"
         )
 
-    projects2 = restParser.run(BRAIN_VOL_FILES, '/projects')
-    OPENNEURO_PROJECT_URI = projects2[0]
-    subjects = restParser.run(BRAIN_VOL_FILES, '/projects/{}/subjects'.format(OPENNEURO_PROJECT_URI))
+    projects2 = restParser.run(OPENNEURO_FILES, '/projects')
+    for p in projects2:
+        proj_info = restParser.run(OPENNEURO_FILES, '/projects/{}'.format(p))
+        if 'dctypes:title' in proj_info.keys() and proj_info['dctypes:title'] == 'Offline Processing in Associative Learning':
+            OPENNEURO_PROJECT_URI = p
+    subjects = restParser.run(OPENNEURO_FILES, '/projects/{}/subjects'.format(OPENNEURO_PROJECT_URI))
     OPENNEURO_SUB_URI = subjects['uuid'][0]
 
 

--- a/nidm/version.py
+++ b/nidm/version.py
@@ -57,5 +57,5 @@ MICRO = _version_micro
 VERSION = __version__
 INSTALL_REQUIRES = ["prov", "graphviz", "pydotplus", "pydot", "validators", "requests", "rapidfuzz", "pygithub",
                     "pandas", "pybids>=0.12.0", "duecredit", "pytest", "graphviz", "click", "rdflib-jsonld",
-                    "pyld", "rdflib", "datalad", "ontquery>=0.2.3", "orthauth>=0.0.12","tabulate", "joblib", "cognitiveatlas", "numpy", "etelemetry","click-option-group"]
+                    "pyld", "rdflib", "datalad", "ontquery>=0.2.3", "orthauth>=0.0.12","tabulate", "joblib", "cognitiveatlas", "numpy>=1.16.5", "etelemetry","click-option-group"]
 SCRIPTS = ["bin/nidm_query", "bin/bidsmri2nidm", "bin/csv2nidm","bin/nidm_utils"]


### PR DESCRIPTION
* Loaded TTL files can be stored in Blazegraph
* Sparql query runner updated to use Blazegraph when available
* command line option --blaze to supply Blazegraph URL
* upgrade version of numpy