### PR TITLE
Now support # in an isabout field URI

### DIFF
--- a/nidm/experiment/Query.py
+++ b/nidm/experiment/Query.py
@@ -667,12 +667,12 @@ def GetDatatypeSynonyms(nidm_file_list, project_id, datatype):
     if datatype.startswith("derivatives."):
         datatype = datatype[12:]
     project_data_elements = GetProjectDataElements(nidm_file_list, project_id)
+    all_synonyms = set([datatype])
     for dti in project_data_elements['data_type_info']:
         if str(datatype) in [ str(x) for x in [dti['source_variable'], dti['label'], dti['datumType'], dti['measureOf'], URITail(dti['measureOf']), str(dti['isAbout']), URITail(dti['isAbout']), dti['dataElement'], dti['dataElementURI'], dti['prefix']] ]:
-            all_synonyms = set([str(dti['source_variable']), str(dti['label']), str(dti['datumType']), str(dti['measureOf']), URITail(dti['measureOf']), str(dti['isAbout']), str(dti['dataElement']), str(dti['dataElementURI'])] )
+            all_synonyms = all_synonyms.union(set([str(dti['source_variable']), str(dti['label']), str(dti['datumType']), str(dti['measureOf']), URITail(dti['measureOf']), str(dti['isAbout']), str(dti['dataElement']), str(dti['dataElementURI'])] ))
             all_synonyms.remove("")  # remove the empty string in case that is in there
-            return list(all_synonyms)
-    return [datatype]
+    return all_synonyms
 
 def GetProjectDataElements(nidm_file_list, project_id):
     ### added by DBK...changing to dictionary to support labels along with uuids

--- a/nidm/experiment/tools/rest.py
+++ b/nidm/experiment/tools/rest.py
@@ -712,7 +712,9 @@ class RestParser:
             self.restLog("Using {} as the graph cache directory".format(gettempdir()), 1)
 
             self.nidm_files = tuple(nidm_files)
-            u = urlparse(command)
+            #replace # marks with %23 - they are sometimes used in the is_about terms
+            escaped = command.replace("#", "%23")
+            u = urlparse(escaped)
             self.command = u.path
             self.query = parse_qs(u.query)
 

--- a/nidm/experiment/tools/rest.py
+++ b/nidm/experiment/tools/rest.py
@@ -434,9 +434,9 @@ class RestParser:
                 for acq in Navigate.getAcquisitions(self.nidm_files, session):
                     act_data = Navigate.getActivityData(self.nidm_files, acq)
                     for de in act_data.data:
-                        if de.isAbout == "http://uri.interlex.org/base/ilx_0100400":
+                        if de.isAbout == "http://uri.interlex.org/ilx_0100400" or de.isAbout == "http://uri.interlex.org/base/ilx_0100400":
                             ages.add(float(de.value))
-                        elif de.isAbout == "http://uri.interlex.org/base/ilx_0101292":
+                        elif de.isAbout == "http://uri.interlex.org/ilx_0101292" or de.isAbout == "http://uri.interlex.org/base/ilx_0101292":
                             genders.add(de.value)
                         elif de.isAbout == "http://purl.obolibrary.org/obo/PATO_0002201":
                             hands.add(de.value)

--- a/nidm/experiment/tools/tests/test_rest.py
+++ b/nidm/experiment/tools/tests/test_rest.py
@@ -587,7 +587,7 @@ def test_multiple_project_fields():
     # rest_parser.setOutputFormat(RestParser.CLI_FORMAT)
     rest_parser.setOutputFormat(RestParser.OBJECT_FORMAT)
 
-    field = 'fs_000003,http://uri.interlex.org/base/ilx_0100400'  # ilx0100400 is 'isAbout' age
+    field = 'fs_000003,ilx_0100400'  # ilx0100400 is 'isAbout' age
     fields = rest_parser.run( BRAIN_VOL_FILES, "/projects?fields={}".format(field) )
 
     # edited by DBK to account for only field values being returned
@@ -606,7 +606,7 @@ def test_odd_isabout_uris():
     # rest_parser.setOutputFormat(RestParser.CLI_FORMAT)
     rest_parser.setOutputFormat(RestParser.OBJECT_FORMAT)
 
-    field = 'http://www.cognitiveatlas.org/ontology/cogat.owl#CAO_00962'  # ilx0100400 is 'isAbout' age
+    field = 'http://www.cognitiveatlas.org/ontology/cogat.owl#CAO_00962'
     fields = rest_parser.run( BRAIN_VOL_FILES, "/projects?fields={}".format(field) )
 
     # edited by DBK to account for only field values being returned
@@ -675,7 +675,7 @@ def test_project_fields_not_found():
 
     assert "error" in keys
 
-
+# ATC - fail
 def test_GetProjectsComputedMetadata():
 
     files = []

--- a/nidm/experiment/tools/tests/test_rest.py
+++ b/nidm/experiment/tools/tests/test_rest.py
@@ -601,6 +601,24 @@ def test_multiple_project_fields():
     assert 'Brain Segmentation Volume (mm^3)' in fields_used
     assert 'age at scan' in fields_used
 
+def test_odd_isabout_uris():
+    rest_parser = RestParser(verbosity_level=0)
+    # rest_parser.setOutputFormat(RestParser.CLI_FORMAT)
+    rest_parser.setOutputFormat(RestParser.OBJECT_FORMAT)
+
+    field = 'http://www.cognitiveatlas.org/ontology/cogat.owl#CAO_00962'  # ilx0100400 is 'isAbout' age
+    fields = rest_parser.run( BRAIN_VOL_FILES, "/projects?fields={}".format(field) )
+
+    # edited by DBK to account for only field values being returned
+    #assert( 'field_values' in project )
+    assert (len(fields) > 0)
+    #fv = project['field_values']
+    print (fields)
+    fv = fields
+    assert( type( fv ) == list )
+    fields_used = set( [ i.label for i in fv ]  )
+    assert 'ADOS_TOTAL' in fields_used
+
 
 def test_project_fields_deriv():
     rest_parser = RestParser(verbosity_level=0)

--- a/pynidm.egg-info/requires.txt
+++ b/pynidm.egg-info/requires.txt
@@ -13,11 +13,7 @@ pytest
 graphviz
 click
 rdflib-jsonld
-<<<<<<< HEAD
 pyld==1.0.5
-=======
-pyld
->>>>>>> 664c997aee3bd6fdc0d2bb21a3689d3eabc3e054
 rdflib
 datalad
 ontquery==0.2.3


### PR DESCRIPTION
* Now can support rest routes like:  /projects?fields=http://www.cognitiveatlas.org/ontology/cogat.owl#CAO_00962
* Fix for the issue with 'base' being included/exclude from the ilx prefix when computing project statistics.