### PR TITLE
Clean up install requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,29 +33,31 @@ install_requires =
     click-option-group
     cognitiveatlas
     datalad
-    duecredit
     etelemetry
-    graphviz
     joblib
     numpy >= 1.16.5
     ontquery ~= 0.2.3
-    orthauth >= 0.0.12
     pandas
     patsy
     prov
     pybids >= 0.12.4
     pydot
-    pydotplus
     pygithub
     pyld >= 1.0.5, <2.0
+    python-dateutil ~= 2.0
     rapidfuzz
     rdflib
-    rdflib-jsonld
     requests
     scikit-learn
+    scipy
     statsmodels
     tabulate
     validators
+
+[options.extras_require]
+tools =
+    matplotlib
+    seaborn
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Some of the packages listed as requirements were not actually in use, and there were some other packages used by pynidm that weren't listed.

Specifically:
* duecredit was unused
* graphviz (the Python project, not to be confused with actual Graphviz) was unused
* orthauth was unused
* pydotplus was unused
* python-dateutil was used but unlisted; the code only worked because it was installed by another dependency
* rdflib-jsonld has been subsumed into rdflib
* scipy was used but unlisted; the code only worked because it was installed by another dependency
* matplotlib and seaborn were unlisted, not installed by anything, and only used by a few files in `nidm/experiment/tools/`, none of which are entry points for the project; I decided to just list them as extras.