### PR TITLE
Remove practically-unused `joblib`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ install_requires =
     cognitiveatlas
     datalad
     etelemetry
-    joblib
     numpy >= 1.16.5
     ontquery ~= 0.2.3
     pandas

--- a/src/nidm/experiment/Query.py
+++ b/src/nidm/experiment/Query.py
@@ -38,16 +38,12 @@ import pickle
 import re
 import tempfile
 from urllib.request import urlretrieve
-from joblib import Memory
 import pandas as pd
 import rdflib
 from rdflib import Graph, URIRef, util
 import requests
 from nidm.core import Constants
 import nidm.experiment.CDE
-
-memory = Memory(tempfile.gettempdir(), verbose=0)
-
 
 QUERY_CACHE_SIZE = 64
 BIG_CACHE_SIZE = 256
@@ -1436,9 +1432,6 @@ def OpenGraph(file):
     rdf_graph.parse(file, format=util.guess_format(file))
     with open(pickle_file, "wb") as fp:
         pickle.dump(rdf_graph, fp)
-
-    # new graph, so to be safe clear out all cached entries
-    memory.clear(warn=False)
 
     return rdf_graph
 

--- a/src/nidm/experiment/tools/rest.py
+++ b/src/nidm/experiment/tools/rest.py
@@ -7,7 +7,6 @@ import re
 from tempfile import gettempdir
 from urllib import parse
 from urllib.parse import parse_qs, urlparse
-from joblib import Memory
 from numpy import mean, median, std
 from tabulate import tabulate
 from nidm.core import Constants
@@ -15,9 +14,6 @@ from nidm.experiment import Navigate, Query
 import nidm.experiment.Navigate
 from nidm.experiment.Utils import validate_uuid
 import nidm.experiment.tools.rest_statistics
-
-memory = Memory(gettempdir(), verbose=0)
-USE_JOBLIB_CACHE = False
 
 
 def convertListtoDict(lst):

--- a/src/nidm/experiment/tools/rest_statistics.py
+++ b/src/nidm/experiment/tools/rest_statistics.py
@@ -1,13 +1,8 @@
 import sys
-from tempfile import gettempdir
-from joblib import Memory
 from nidm.core import Constants
 from nidm.experiment import Navigate
 import nidm.experiment.Navigate
 import nidm.experiment.tools.rest
-
-memory = Memory(gettempdir(), verbose=0)
-USE_JOBLIB_CACHE = False
 
 
 def GetProjectsComputedMetadata(nidm_file_list):


### PR DESCRIPTION
`joblib.Memory` was imported & instantiated in a few places, but nothing was done with it.