### PR TITLE
Use `.readthedocs.yaml` file to install pynidm in RTD environment

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+formats: all
+python:
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3"
+sphinx:
+  configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+Sphinx
+sphinx-rtd-theme

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,7 @@ commands =
 
 [testenv:docs]
 basepython = python3
-deps =
-    Sphinx
-    sphinx-rtd-theme
+deps = -rdocs/requirements.txt
 changedir = docs
 commands = sphinx-build -E -W -b html source build
 


### PR DESCRIPTION
This should get the docs building again.