### PR TITLE
Open all text files with UTF-8 encoding

### DIFF
--- a/src/nidm/experiment/Query.py
+++ b/src/nidm/experiment/Query.py
@@ -1347,7 +1347,7 @@ def OpenGraph(file):
     # If we have a Blazegraph instance, load the data then do the rest
     if "BLAZEGRAPH_URL" in environ.keys():
         try:
-            with open(file) as f:
+            with open(file, encoding="utf-8") as f:
                 data = f.read()
             logging.debug("Sending %s to blazegraph", file)
             requests.post(

--- a/src/nidm/experiment/Utils.py
+++ b/src/nidm/experiment/Utils.py
@@ -1446,7 +1446,7 @@ def map_variables_to_terms(
             # check if json_source is a file
             if os.path.isfile(json_source):
                 # load file
-                with open(json_source, "r") as f:
+                with open(json_source, "r", encoding="utf-8") as f:
                     json_map = json.load(f)
             else:
                 print(f"ERROR: Can't open json mapping file: {json_source}")
@@ -2157,6 +2157,7 @@ def write_json_mapping_file(source_variable_annotations, output_file, bids=False
                 os.path.dirname(output_file), os.path.splitext(output_file)[0] + ".json"
             ),
             "w+",
+            encoding="utf-8",
         ) as fp:
             json.dump(new_dict, fp, indent=4)
     else:
@@ -2168,6 +2169,7 @@ def write_json_mapping_file(source_variable_annotations, output_file, bids=False
                 os.path.splitext(output_file)[0] + "_annotations.json",
             ),
             "w+",
+            encoding="utf-8",
         ) as fp:
             json.dump(source_variable_annotations, fp, indent=4)
 

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -197,7 +197,7 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
         rdf_graph.serialize(destination=outputfile, format="turtle")
 
     # serialize NIDM file
-    # with open(outputfile,'w') as f:
+    # with open(outputfile,'w', encoding="utf-8") as f:
     #     if args.jsonld:
     #         f.write(project.serializeJSONLD())
     #     else:
@@ -215,12 +215,16 @@ def addbidsignore(directory, filename_to_add):
     logging.info("Adding file %s to %s/.bidsignore...", filename_to_add, directory)
     # adds filename_to_add to .bidsignore file in directory
     if not isfile(os.path.join(directory, ".bidsignore")):
-        with open(os.path.join(directory, ".bidsignore"), "w") as text_file:
+        with open(
+            os.path.join(directory, ".bidsignore"), "w", encoding="utf-8"
+        ) as text_file:
             text_file.write("%s\n" % filename_to_add)
     else:
-        with open(os.path.join(directory, ".bidsignore")) as fp:
+        with open(os.path.join(directory, ".bidsignore"), encoding="utf-8") as fp:
             if filename_to_add not in fp.read():
-                with open(os.path.join(directory, ".bidsignore"), "a") as text_file:
+                with open(
+                    os.path.join(directory, ".bidsignore"), "a", encoding="utf-8"
+                ) as text_file:
                     text_file.write("%s\n" % filename_to_add)
 
 
@@ -373,7 +377,9 @@ def addimagingsessions(
             # Parse T1w.json file in BIDS directory to add the attributes contained inside
             if os.path.isdir(os.path.join(directory)):
                 try:
-                    with open(os.path.join(directory, "T1w.json")) as data_file:
+                    with open(
+                        os.path.join(directory, "T1w.json"), encoding="utf-8"
+                    ) as data_file:
                         dataset = json.load(data_file)
                 except OSError:
                     logging.warning(
@@ -384,7 +390,8 @@ def addimagingsessions(
                             with open(
                                 os.path.join(
                                     directory, "ses-" + img_session + "_T1w.json"
-                                )
+                                ),
+                                encoding="utf-8",
                             ) as data_file:
                                 dataset = json.load(data_file)
                         else:
@@ -567,7 +574,7 @@ def addimagingsessions(
             if os.path.isdir(os.path.join(directory)):
                 try:
                     with open(
-                        os.path.join(directory, "task-rest_bold.json")
+                        os.path.join(directory, "task-rest_bold.json"), encoding="utf-8"
                     ) as data_file:
                         dataset = json.load(data_file)
                 except OSError:
@@ -580,7 +587,8 @@ def addimagingsessions(
                                 os.path.join(
                                     directory,
                                     "ses-" + img_session + "_task-rest_bold.json",
-                                )
+                                ),
+                                encoding="utf-8",
                             ) as data_file:
                                 dataset = json.load(data_file)
                         else:
@@ -930,7 +938,9 @@ def bidsmri2project(directory, args):
     # Parse dataset_description.json file in BIDS directory
     if os.path.isdir(os.path.join(directory)):
         try:
-            with open(os.path.join(directory, "dataset_description.json")) as data_file:
+            with open(
+                os.path.join(directory, "dataset_description.json"), encoding="utf-8"
+            ) as data_file:
                 dataset = json.load(data_file)
         except OSError:
             logging.critical(
@@ -985,7 +995,9 @@ def bidsmri2project(directory, args):
     participant = {}
     # Parse participants.tsv file in BIDS directory and create study and acquisition objects
     if os.path.isfile(os.path.join(directory, "participants.tsv")):
-        with open(os.path.join(directory, "participants.tsv")) as csvfile:
+        with open(
+            os.path.join(directory, "participants.tsv"), encoding="utf-8"
+        ) as csvfile:
             participants_data = csv.DictReader(csvfile, delimiter="\t")
 
             # logic to create data dictionaries for variables and/or use them if they already exist.
@@ -1300,7 +1312,7 @@ def bidsmri2project(directory, args):
     for tsv_file in glob.glob(os.path.join(directory, "phenotype", "*.tsv")):
         # for now, open the TSV file, extract the row for this subject, store it in an acquisition object and link to
         # the associated JSON data dictionary file
-        with open(tsv_file) as phenofile:
+        with open(tsv_file, encoding="utf-8") as phenofile:
             pheno_data = csv.DictReader(phenofile, delimiter="\t")
             mapping_list = []
             column_to_terms = {}

--- a/src/nidm/experiment/tools/csv2nidm.py
+++ b/src/nidm/experiment/tools/csv2nidm.py
@@ -182,7 +182,7 @@ def main():
 
         # read in NIDM file
         project = read_nidm(args.nidm_file)
-        # with open("/Users/dbkeator/Downloads/test.ttl","w") as f:
+        # with open("/Users/dbkeator/Downloads/test.ttl","w", encoding="utf-8") as f:
         #    f.write(project.serializeTurtle())
 
         # get list of session objects

--- a/src/nidm/experiment/tools/nidm2bids.py
+++ b/src/nidm/experiment/tools/nidm2bids.py
@@ -362,7 +362,7 @@ def CreateBIDSParticipantFile(nidm_graph, output_file, participant_fields):
     # save participants.tsv file
     participants.to_csv(output_file + ".tsv", sep="\t", index=False)
     # save participants.json file
-    with open(output_file + ".json", "w") as f:
+    with open(output_file + ".json", "w", encoding="utf-8") as f:
         json.dump(participants_json, f, sort_keys=True, indent=2)
 
     # save participant sidecar file
@@ -412,7 +412,9 @@ def NIDMProject2BIDSDatasetDescriptor(nidm_graph, output_directory):
         if not key_found:
             del project_metadata[proj_key]
 
-    with open(join(output_directory, "dataset_description.json"), "w") as f:
+    with open(
+        join(output_directory, "dataset_description.json"), "w", encoding="utf-8"
+    ) as f:
         json.dump(project_metadata, f, sort_keys=True, indent=2)
 
 
@@ -447,7 +449,9 @@ def AddMetadataToImageSidecar(graph_entity, graph, output_directory, image_filen
             json_dict[key] = row[1]
 
     # write json_dict out to appropriate sidecar filename
-    with open(join(output_directory, image_filename + ".json"), "w") as fp:
+    with open(
+        join(output_directory, image_filename + ".json"), "w", encoding="utf-8"
+    ) as fp:
         json.dump(json_dict, fp, indent=2)
 
 
@@ -840,7 +844,7 @@ def main():
             # load NIDM graph into NIDM-Exp API objects
             nidm_project = read_nidm(rdf_file)
             # temporary save nidm_project
-            with open("/Users/dbkeator/Downloads/nidm.ttl", "w") as f:
+            with open("/Users/dbkeator/Downloads/nidm.ttl", "w", encoding="utf-8") as f:
                 print(nidm_project.serializeTurtle(), file=f)
             print("RDF file successfully read")
             format_found = True

--- a/src/nidm/experiment/tools/nidm_affinity_propagation.py
+++ b/src/nidm/experiment/tools/nidm_affinity_propagation.py
@@ -54,7 +54,7 @@ def data_aggregation():  # all data from all the files is collected
 
         print("Your command was: " + command)
         if o is not None:
-            with open(o, "w") as f:
+            with open(o, "w", encoding="utf-8") as f:
                 f.write("Your command was " + command)
         verbosity = 0
         restParser = RestParser(verbosity_level=int(verbosity))
@@ -115,7 +115,7 @@ def data_aggregation():  # all data from all the files is collected
             ) as temp:  # turns the dataframe into a temporary csv
                 df.to_csv(temp.name + ".csv")
                 temp.close()
-            with open(temp.name + ".csv") as fp:
+            with open(temp.name + ".csv", encoding="utf-8") as fp:
                 data = list(
                     csv.reader(fp)
                 )  # makes the csv a 2D list to make it easier to call the contents of certain cells
@@ -251,7 +251,7 @@ def data_aggregation():  # all data from all the files is collected
                     + ". The model cannot run because this will skew the data. Try checking your spelling or use nidm_query.py to see other possible variables."
                 )
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write("Your variables were " + v)
                         f.write(
                             "The following variables were not found in "
@@ -261,7 +261,7 @@ def data_aggregation():  # all data from all the files is collected
                 for i in range(0, len(not_found_list)):
                     print(str(i + 1) + ". " + not_found_list[i])
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(str(i + 1) + ". " + not_found_list[i])
                 for j in range(len(not_found_list) - 1, 0, -1):
                     not_found_list.pop(j)
@@ -332,7 +332,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     print("*" * 107)
     print()
     if o is not None:
-        with open(o, "a") as f:
+        with open(o, "a", encoding="utf-8") as f:
             f.write(df_final.to_string(header=True, index=True))
             f.write("\n\n" + ("*" * 107))
             f.write("\n\nModel Results: ")
@@ -387,7 +387,7 @@ def ap():
     plt.title(title)
     plt.show()
     if o is not None:
-        with open(o, "a"):
+        with open(o, "a", encoding="utf-8"):
             pass
 
 

--- a/src/nidm/experiment/tools/nidm_agglomerative_clustering.py
+++ b/src/nidm/experiment/tools/nidm_agglomerative_clustering.py
@@ -54,7 +54,7 @@ def data_aggregation():  # all data from all the files is collected
 
         print("Your command was: " + command)
         if o is not None:
-            with open(o, "w") as f:
+            with open(o, "w", encoding="utf-8") as f:
                 f.write("Your command was " + command)
         verbosity = 0
         restParser = RestParser(verbosity_level=int(verbosity))
@@ -115,7 +115,7 @@ def data_aggregation():  # all data from all the files is collected
             ) as temp:  # turns the dataframe into a temporary csv
                 df.to_csv(temp.name + ".csv")
                 temp.close()
-            with open(temp.name + ".csv") as fp:
+            with open(temp.name + ".csv", encoding="utf-8") as fp:
                 data = list(
                     csv.reader(fp)
                 )  # makes the csv a 2D list to make it easier to call the contents of certain cells
@@ -251,7 +251,7 @@ def data_aggregation():  # all data from all the files is collected
                     + ". The model cannot run because this will skew the data. Try checking your spelling or use nidm_query.py to see other possible variables."
                 )
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write("Your variables were " + v)
                         f.write(
                             "The following variables were not found in "
@@ -261,7 +261,7 @@ def data_aggregation():  # all data from all the files is collected
                 for i in range(0, len(not_found_list)):
                     print(str(i + 1) + ". " + not_found_list[i])
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(str(i + 1) + ". " + not_found_list[i])
                 for j in range(len(not_found_list) - 1, 0, -1):
                     not_found_list.pop(j)
@@ -332,7 +332,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     print("*" * 107)
     print()
     if o is not None:
-        with open(o, "a") as f:
+        with open(o, "a", encoding="utf-8") as f:
             f.write(df_final.to_string(header=True, index=True))
             f.write("\n\n" + ("*" * 107))
             f.write("\n\nModel Results: ")
@@ -375,7 +375,7 @@ def ac():
     plt.show()
 
     if o is not None:
-        with open(o, "a"):
+        with open(o, "a", encoding="utf-8"):
             pass
 
 

--- a/src/nidm/experiment/tools/nidm_convert.py
+++ b/src/nidm/experiment/tools/nidm_convert.py
@@ -49,14 +49,14 @@ def convert(nidm_file_list, outtype, outdir):
             # read in nidm file
             project = read_nidm(nidm_file)
             # write jsonld file with same name
-            with open(outfile + ".json", "w") as f:
+            with open(outfile + ".json", "w", encoding="utf-8") as f:
                 f.write(project.serializeJSONLD())
         elif outtype == "turtle":
             # graph = Graph()
             # graph.parse(nidm_file, format=util.guess_format(nidm_file))
             # graph.serialize(splitext(nidm_file)[0] + ".ttl", format='turtle')
             project = read_nidm(nidm_file)
-            with open(outfile + ".ttl", "w") as f:
+            with open(outfile + ".ttl", "w", encoding="utf-8") as f:
                 f.write(project.serializeTurtle())
         elif outtype == "xml-rdf":
             graph = Graph()
@@ -69,7 +69,7 @@ def convert(nidm_file_list, outtype, outdir):
         elif outtype == "trig":
             # read in nidm file
             project = read_nidm(nidm_file)
-            with open(outfile + ".trig", "w") as f:
+            with open(outfile + ".trig", "w", encoding="utf-8") as f:
                 f.write(project.serializeTrig())
         else:
             print("Error, type is not supported at this time")

--- a/src/nidm/experiment/tools/nidm_gmm.py
+++ b/src/nidm/experiment/tools/nidm_gmm.py
@@ -83,7 +83,7 @@ def data_aggregation():  # all data from all the files is collected
 
         print("Your command was: " + command)
         if o is not None:
-            with open(o, "w") as f:
+            with open(o, "w", encoding="utf-8") as f:
                 f.write("Your command was " + command)
         verbosity = 0
         restParser = RestParser(verbosity_level=int(verbosity))
@@ -147,7 +147,7 @@ def data_aggregation():  # all data from all the files is collected
                 df.to_csv(temp.name + ".csv")
                 temp.close()
 
-            with open(temp.name + ".csv") as fp:
+            with open(temp.name + ".csv", encoding="utf-8") as fp:
                 data = list(
                     csv.reader(fp)
                 )  # makes the csv a 2D list to make it easier to call the contents of certain cells
@@ -290,7 +290,7 @@ def data_aggregation():  # all data from all the files is collected
                     + ". The model cannot run because this will skew the data. Try checking your spelling or use nidm_query.py to see other possible variables."
                 )
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write("Your variables were " + v)
                         f.write(
                             "The following variables were not found in "
@@ -300,7 +300,7 @@ def data_aggregation():  # all data from all the files is collected
                 for i in range(0, len(not_found_list)):
                     print(str(i + 1) + ". " + not_found_list[i])
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(str(i + 1) + ". " + not_found_list[i])
                 for j in range(len(not_found_list) - 1, 0, -1):
                     not_found_list.pop(j)
@@ -381,7 +381,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     print("*" * 107)
     print()
     if o is not None:
-        with open(o, "a") as f:
+        with open(o, "a", encoding="utf-8") as f:
             f.write(df_final.to_string(header=True, index=True))
             f.write("\n\n" + ("*" * 107))
             f.write("\n\nModel Results: ")
@@ -552,7 +552,7 @@ def cluster_number():
         plt.show()
 
     if o is not None:
-        with open(o, "a"):
+        with open(o, "a", encoding="utf-8"):
             pass
 
 

--- a/src/nidm/experiment/tools/nidm_kmeans.py
+++ b/src/nidm/experiment/tools/nidm_kmeans.py
@@ -90,7 +90,7 @@ def data_aggregation():  # all data from all the files is collected
 
         print("Your command was: " + command)
         if o is not None:
-            with open(o, "w") as f:
+            with open(o, "w", encoding="utf-8") as f:
                 f.write("Your command was " + command)
         verbosity = 0
         restParser = RestParser(verbosity_level=int(verbosity))
@@ -153,7 +153,7 @@ def data_aggregation():  # all data from all the files is collected
             ) as temp:  # turns the dataframe into a temporary csv
                 df.to_csv(temp.name + ".csv")
                 temp.close()
-            with open(temp.name + ".csv") as fp:
+            with open(temp.name + ".csv", encoding="utf-8") as fp:
                 data = list(
                     csv.reader(fp)
                 )  # makes the csv a 2D list to make it easier to call the contents of certain cells
@@ -296,7 +296,7 @@ def data_aggregation():  # all data from all the files is collected
                     + ". The model cannot run because this will skew the data. Try checking your spelling or use nidm_query.py to see other possible variables."
                 )
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write("Your variables were " + v)
                         f.write(
                             "The following variables were not found in "
@@ -306,7 +306,7 @@ def data_aggregation():  # all data from all the files is collected
                 for i in range(0, len(not_found_list)):
                     print(str(i + 1) + ". " + not_found_list[i])
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(str(i + 1) + ". " + not_found_list[i])
                 for j in range(len(not_found_list) - 1, 0, -1):
                     not_found_list.pop(j)
@@ -387,7 +387,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     print("*" * 107)
     print()
     if o is not None:
-        with open(o, "a") as f:
+        with open(o, "a", encoding="utf-8") as f:
             f.write(df_final.to_string(header=True, index=True))
             f.write("\n\n" + ("*" * 107))
             f.write("\n\nModel Results: ")
@@ -639,7 +639,7 @@ def cluster_number():
         # ask for help: how does one do a dendrogram, also without graphing?
 
     if o is not None:
-        f = open(o, "a")
+        f = open(o, "a", encoding="utf-8")
         f.close()
 
 

--- a/src/nidm/experiment/tools/nidm_linreg.py
+++ b/src/nidm/experiment/tools/nidm_linreg.py
@@ -93,7 +93,7 @@ def data_aggregation():  # all data from all the files is collected
             command = command + "-r " + r + " "
         print("Your command was: " + command)
         if o is not None:
-            with open(o, "w") as f:
+            with open(o, "w", encoding="utf-8") as f:
                 f.write("Your command was " + command)
         verbosity = 0
         restParser = RestParser(verbosity_level=int(verbosity))
@@ -161,7 +161,7 @@ def data_aggregation():  # all data from all the files is collected
                         + '" from either the right or the left side of the equation.\n\n'
                     )
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(
                                 "\n\nAn independent variable cannot be the same as the dependent variable. This prevents the model from running accurately."
                             )
@@ -191,7 +191,7 @@ def data_aggregation():  # all data from all the files is collected
             ) as temp:  # turns the dataframe into a temporary csv
                 df.to_csv(temp.name + ".csv")
                 temp.close()
-            with open(temp.name + ".csv") as fp:
+            with open(temp.name + ".csv", encoding="utf-8") as fp:
                 data = list(
                     csv.reader(fp)
                 )  # makes the csv a 2D list to make it easier to call the contents of certain cells
@@ -355,7 +355,7 @@ def data_aggregation():  # all data from all the files is collected
                     + ". The model cannot run because this will skew the data. Try checking your spelling or use nidm_query.py to see other possible variables."
                 )
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write("Your model was " + m)
                         f.write(
                             "The following variables were not found in "
@@ -365,7 +365,7 @@ def data_aggregation():  # all data from all the files is collected
                 for i in range(0, len(not_found_list)):
                     print(str(i + 1) + ". " + not_found_list[i])
                     if o is not None:
-                        with open(o, "a") as f:
+                        with open(o, "a", encoding="utf-8") as f:
                             f.write(str(i + 1) + ". " + not_found_list[i])
                 for j in range(len(not_found_list) - 1, 0, -1):
                     not_found_list.pop(j)
@@ -407,7 +407,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
         warnings.filterwarnings("ignore")
         answer = input("Continue anyways? Y or N: ")
         if o is not None:
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write("Your model was " + m)
                 f.write(
                     "\n\nThere was a lack of data (<20 points) in your model, which may result in inaccuracies. In addition, a regularization cannot and will not be performed.\n"
@@ -415,7 +415,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     if "n" in answer.lower():
         print("\nModel halted.")
         if o is not None:
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write("Your model was " + m)
                 f.write(
                     "Due to a lack of data (<20 points), you stopped the model because the results may have been inaccurate."
@@ -471,7 +471,7 @@ def dataparsing():  # The data is changed to a format that is usable by the line
     print("*" * 107)
     print()
     if o is not None:
-        with open(o, "a") as f:
+        with open(o, "a", encoding="utf-8") as f:
             f.write(df_final.to_string(header=True, index=True))
             f.write("\n\n" + ("*" * 107))
             f.write("\n\nModel Results: ")
@@ -540,7 +540,7 @@ def linreg():  # actual linear regression
         print(finalstats.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as fp:
+            with open(o, "a", encoding="utf-8") as fp:
                 print(full_model, file=fp)
                 print("\n" + ("*" * 85) + "\n", file=fp)
                 print(finalstats.summary(), file=fp)
@@ -607,7 +607,7 @@ def contrasting():
         print(res.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write("\n" + full_model)
                 f.write("\n\n" + ("*" * 107))
                 f.write(
@@ -654,7 +654,7 @@ def contrasting():
         print(res.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write(
                     "\n\n\nSimple Coding: Like Treatment Coding, Simple Coding compares each level to a fixed reference level. However, with simple coding, the intercept is the grand mean of all the levels of the factors."
                 )
@@ -678,7 +678,7 @@ def contrasting():
         print(res.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write(
                     "\n\n\nSum (Deviation) Coding: Sum coding compares the mean of the dependent variable for a given level to the overall mean of the dependent variable over all the levels."
                 )
@@ -702,7 +702,7 @@ def contrasting():
         print(res.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write(
                     "\n\n\nBackward Difference Coding: In backward difference coding, the mean of the dependent variable for a level is compared with the mean of the dependent variable for the prior level."
                 )
@@ -726,7 +726,7 @@ def contrasting():
         print(res.summary())
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write(
                     "\n\n\nHelmert Coding: Our version of Helmert coding is sometimes referred to as Reverse Helmert Coding. The mean of the dependent variable for a level is compared to the mean of the dependent variable over all previous levels. Hence, the name ‘reverse’ being sometimes applied to differentiate from forward Helmert coding."
                 )
@@ -764,7 +764,7 @@ def regularizing():
         print("\nCoefficients:")
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write("\n\nLasso regression model:")
                 f.write(
                     f"\nAlpha with maximum likelihood (range: 1 to {MAX_ALPHA}) = {max_cross_val_alpha}"
@@ -774,12 +774,12 @@ def regularizing():
         for var in full_model_variable_list:
             print(f"{var} \t {lassoModelChosen.coef_[index]}")
             if o is not None:
-                with open(o, "a") as f:
+                with open(o, "a", encoding="utf-8") as f:
                     f.write(f"\n{var} \t {lassoModelChosen.coef_[index]}")
             index = index + 1
         print(f"Intercept: {lassoModelChosen.intercept_}")
         if o is not None:
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write(f"\nIntercept: {lassoModelChosen.intercept_}")
         print()
 
@@ -819,7 +819,7 @@ def regularizing():
                 numpy_conversion = True
         if o is not None:
             # concatenate data frames
-            with open(o, "a") as f:
+            with open(o, "a", encoding="utf-8") as f:
                 f.write("\n\nRidge regression model:")
                 f.write(
                     f"\nAlpha with maximum likelihood (range: 1 to {MAX_ALPHA}) = {max_cross_val_alpha}"
@@ -833,24 +833,24 @@ def regularizing():
             for var in full_model_variable_list:
                 print(f"{var} \t {coeff_list[index]}")
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write(f"\n{var} \t {coeff_list[index]}")
                 index = index + 1
             print(f"Intercept: {ridgeModelChosen.intercept_}")
             if o is not None:
-                with open(o, "a") as f:
+                with open(o, "a", encoding="utf-8") as f:
                     f.write(f"\nIntercept: {ridgeModelChosen.intercept_}")
             print()
         else:
             for var in full_model_variable_list:
                 print(f"{var} \t {ridgeModelChosen.coef_[index]}")
                 if o is not None:
-                    with open(o, "a") as f:
+                    with open(o, "a", encoding="utf-8") as f:
                         f.write(f"\n{var} \t {ridgeModelChosen.coef_[index]}")
                 index = index + 1
             print(f"Intercept: {ridgeModelChosen.intercept_}")
             if o is not None:
-                with open(o, "a") as f:
+                with open(o, "a", encoding="utf-8") as f:
                     f.write(f"\nIntercept: {ridgeModelChosen.intercept_}")
             print()
 

--- a/src/nidm/experiment/tools/nidm_query.py
+++ b/src/nidm/experiment/tools/nidm_query.py
@@ -164,7 +164,7 @@ def query(
         # if output file parameter specified
         if output_file is not None:
             df.to_csv(output_file)
-            # with open(output_file,'w') as myfile:
+            # with open(output_file,'w', encoding="utf-8") as myfile:
             #    wr=csv.writer(myfile,quoting=csv.QUOTE_ALL)
             #    wr.writerow(df)
 
@@ -243,7 +243,7 @@ def query(
         df = restParser.run(nidm_file_list.split(","), uri)
         if output_file is not None:
             if j:
-                with open(output_file, "w+") as f:
+                with open(output_file, "w+", encoding="utf-8") as f:
                     f.write(dumps(df))
             else:
                 # convert object df to dataframe and output

--- a/src/nidm/experiment/tools/nidm_utils.py
+++ b/src/nidm/experiment/tools/nidm_utils.py
@@ -99,7 +99,9 @@ def main():
         for nidm_file in args.nidm_files:
             project = read_nidm(nidm_file)
             # serialize to jsonld
-            with open(os.path.splitext(nidm_file)[0] + ".json", "w") as f:
+            with open(
+                os.path.splitext(nidm_file)[0] + ".json", "w", encoding="utf-8"
+            ) as f:
                 f.write(project.serializeJSONLD())
 
 

--- a/src/nidm/experiment/tools/repronim_simple2_brainvolumes.py
+++ b/src/nidm/experiment/tools/repronim_simple2_brainvolumes.py
@@ -232,7 +232,7 @@ def add_brainvolume_data(
             if png_file is not None:
                 if first_row:
                     # serialize NIDM file
-                    # with open(args.output_file,'w') as f:
+                    # with open(args.output_file,'w', encoding="utf-8") as f:
                     #   print("Writing NIDM file...")
                     #   f.write(nidmdoc.serializeTurtle())
                     if png_file:
@@ -510,7 +510,7 @@ def add_brainvolume_data(
             # if png_file is not None:
             #    if first_row:
             # serialize NIDM file
-            # with open(args.output_file,'w') as f:
+            # with open(args.output_file,'w', encoding="utf-8") as f:
             #   print("Writing NIDM file...")
             #   f.write(nidmdoc.serializeTurtle())
             #        nidmdoc.save_DotGraph(str(output_file + ".pdf"), format="pdf")
@@ -643,7 +643,7 @@ def main():
         )
 
         # serialize NIDM file
-        with open(args.output_file, "w") as f:
+        with open(args.output_file, "w", encoding="utf-8") as f:
             print("Writing NIDM file...")
             f.write(project.serializeTurtle())
             # if args.png:
@@ -709,7 +709,7 @@ def main():
     #                continue
 
     #        #serialize NIDM file
-    #        with open(args.nidm_file,'w') as f:
+    #        with open(args.nidm_file,'w', encoding="utf-8") as f:
     #            print("Writing NIDM file...")
     #            f.write(project.serializeTurtle())
     #            project.save_DotGraph(str(args.nidm_file + ".png"), format="png")
@@ -741,7 +741,7 @@ def main():
         )
 
         # serialize NIDM file
-        with open(args.output_file, "w") as f:
+        with open(args.output_file, "w", encoding="utf-8") as f:
             print("Writing NIDM file...")
             f.write(nidmdoc.serializeTurtle())
             if args.png:

--- a/tests/core/test_provone.py
+++ b/tests/core/test_provone.py
@@ -37,7 +37,7 @@ def test_ispartof(doc, tmp_path) -> None:
     doc.isPartOf(pe1, workflow_1ex1)
 
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
 
 
@@ -56,7 +56,7 @@ def test_used(doc, tmp_path) -> None:
     doc.used(pe1, dt1)
 
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
 
 
@@ -73,7 +73,7 @@ def test_wasderivedfrom(doc, tmp_path) -> None:
     doc.wasDerivedFrom(dt1, dt2)
 
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
 
 
@@ -81,7 +81,7 @@ def test_dataonlink(doc, tmp_path) -> None:
     dt2 = doc.data("dcterms:identifier:defparam2", {"rdfs:label": "filename"})
     dl1 = doc.dataLink("dcterms:identifier:e1_e2DL")
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
     doc.dataOnLink(dt2, dl1)
 
@@ -93,7 +93,7 @@ def test_wasgeneratedby(doc, tmp_path) -> None:
     )
     doc.wasGeneratedBy(dt2, pe1)
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
 
 
@@ -137,7 +137,7 @@ def test_dltoinport(doc):
 
 def test_documentserialize(doc, tmp_path) -> None:
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(doc.serialize(format="rdf", rdf_format="ttl"))
 
 

--- a/tests/experiment/create_testfile.py
+++ b/tests/experiment/create_testfile.py
@@ -76,7 +76,7 @@ def main():
     acq_entity.add_attributes({Constants.NIDM_AGE: 60, Constants.NIDM_GENDER: "Male"})
 
     # save a turtle file
-    with open("test_nidm.ttl", "w") as f:
+    with open("test_nidm.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     # save a DOT graph as PDF

--- a/tests/experiment/read_nidm.py
+++ b/tests/experiment/read_nidm.py
@@ -37,7 +37,7 @@ def main():
         derivobj = deriv.get_derivative_objects()
         print(f"Derivative Objects: \n {derivobj}")
 
-    with open(args.outfile, "w") as f:
+    with open(args.outfile, "w", encoding="utf-8") as f:
         # serialize project for comparison with the original
         f.write(project.serializeTurtle())
 

--- a/tests/experiment/test_experiment.py
+++ b/tests/experiment/test_experiment.py
@@ -92,7 +92,7 @@ def main():
     acq_entity.add_attributes({Constants.NIDM_AGE: 60, Constants.NIDM_GENDER: "Male"})
 
     # save a turtle file
-    with open("test.ttl", "w") as f:
+    with open("test.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     # save a DOT graph as PDF

--- a/tests/experiment/test_experiment_basic.py
+++ b/tests/experiment/test_experiment_basic.py
@@ -10,7 +10,7 @@ from nidm.experiment import Project, Session
 def test_1(tmp_path: Path) -> None:
     project = Project()
     # save a turtle file
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
 
@@ -22,7 +22,7 @@ def test_2(tmp_path: Path) -> None:
     }
     project = Project(attributes=kwargs)
 
-    with open(tmp_path / "test.ttl", "w") as f:
+    with open(tmp_path / "test.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
 
@@ -185,11 +185,11 @@ def test_jsonld_exports(tmp_path: Path) -> None:
     project = Project(uuid="_123456", attributes=kwargs)
 
     # save a turtle file
-    with open(tmp_path / "test.json", "w") as f:
+    with open(tmp_path / "test.json", "w", encoding="utf-8") as f:
         f.write(project.serializeJSONLD())
 
     # load in JSON file
-    with open(tmp_path / "test.json") as json_file:
+    with open(tmp_path / "test.json", encoding="utf-8") as json_file:
         data = json.load(json_file)
 
     assert data["Identifier"]["@value"] == "9610"

--- a/tests/experiment/test_map_vars_to_terms.py
+++ b/tests/experiment/test_map_vars_to_terms.py
@@ -205,7 +205,7 @@ def test_map_vars_to_terms_BIDS(setup: Setup, tmp_path: Path) -> None:
     )
 
     # now check the JSON sidecar file created by map_variables_to_terms which should match BIDS format
-    with open(tmp_path / "nidm_annotations.json") as fp:
+    with open(tmp_path / "nidm_annotations.json", encoding="utf-8") as fp:
         bids_sidecar = json.load(fp)
 
     assert "age" in bids_sidecar.keys()
@@ -306,7 +306,7 @@ def test_map_vars_to_terms_reproschema(setup: Setup, tmp_path: Path) -> None:
     )
 
     # now check the JSON mapping file created by map_variables_to_terms which should match Reproschema format
-    with open(tmp_path / "nidm_annotations_annotations.json") as fp:
+    with open(tmp_path / "nidm_annotations_annotations.json", encoding="utf-8") as fp:
         json.load(fp)
 
     assert "DD(source='test', variable='age')" in column_to_terms.keys()

--- a/tests/experiment/test_query.py
+++ b/tests/experiment/test_query.py
@@ -51,7 +51,7 @@ def test_GetProjectMetadata(tmp_path: Path) -> None:
     project = Project(uuid="_123456", attributes=kwargs)
 
     # save a turtle file
-    with open(tmp_path / "test_gpm.ttl", "w") as f:
+    with open(tmp_path / "test_gpm.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     kwargs = {
@@ -62,7 +62,7 @@ def test_GetProjectMetadata(tmp_path: Path) -> None:
     project = Project(uuid="_654321", attributes=kwargs)
 
     # save a turtle file
-    with open(tmp_path / "test2_gpm.ttl", "w") as f:
+    with open(tmp_path / "test2_gpm.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     # WIP test = Query.GetProjectMetadata(["test.ttl", "test2.ttl"])
@@ -86,7 +86,7 @@ def test_GetProjects(tmp_path: Path) -> None:
     project = Project(uuid="_123456", attributes=kwargs)
 
     # save a turtle file
-    with open(tmp_path / "test_gp.ttl", "w") as f:
+    with open(tmp_path / "test_gp.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     project_list = Query.GetProjectsUUID([str(tmp_path / "test_gp.ttl")])
@@ -112,7 +112,7 @@ def test_GetParticipantIDs(tmp_path: Path) -> None:
     acq2.add_qualified_association(person=person2, role=Constants.NIDM_PARTICIPANT)
 
     # save a turtle file
-    with open(tmp_path / "test_3.ttl", "w") as f:
+    with open(tmp_path / "test_3.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     participant_list = Query.GetParticipantIDs([str(tmp_path / "test_3.ttl")])
@@ -150,7 +150,7 @@ def test_GetProjectInstruments(tmp_path: Path) -> None:
     AssessmentObject(acq2, attributes=kwargs)
 
     # save a turtle file
-    with open(tmp_path / "test_gpi.ttl", "w") as f:
+    with open(tmp_path / "test_gpi.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     assessment_list = Query.GetProjectInstruments(
@@ -201,7 +201,7 @@ def saveTestFile(file_name, data):
 
 def saveProject(file_name, project):
     # save a turtle file
-    with open(file_name, "w") as f:
+    with open(file_name, "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
     return f"nidm:_123_{file_name}"
 

--- a/tests/experiment/tools/test_rest.py
+++ b/tests/experiment/tools/test_rest.py
@@ -160,9 +160,9 @@ def makeTestFile(dirpath: Path, filename: str, params: dict) -> RestTest:
         str(person5.identifier).replace("niiri:", ""),
     ]
 
-    with open(dirpath / "a.ttl", "w") as f:
+    with open(dirpath / "a.ttl", "w", encoding="utf-8") as f:
         f.write(project.graph.serialize(None, format="rdf", rdf_format="ttl"))
-    with open(dirpath / "b.ttl", "w") as f:
+    with open(dirpath / "b.ttl", "w", encoding="utf-8") as f:
         f.write(project2.graph.serialize(None, format="rdf", rdf_format="ttl"))
 
     # create empty graph
@@ -227,7 +227,7 @@ def test_uri_project_list(tmp_path: Path) -> None:
     proj2_uuid = str(uuid.uuid1())
     project = Project(uuid=proj1_uuid, attributes=kwargs)
     # save a turtle file
-    with open(tmp_path / "uritest.ttl", "w") as f:
+    with open(tmp_path / "uritest.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     kwargs = {
@@ -237,7 +237,7 @@ def test_uri_project_list(tmp_path: Path) -> None:
     }
     project = Project(uuid=proj2_uuid, attributes=kwargs)
     # save a turtle file
-    with open(tmp_path / "uritest2.ttl", "w") as f:
+    with open(tmp_path / "uritest2.ttl", "w", encoding="utf-8") as f:
         f.write(project.serializeTurtle())
 
     restParser = RestParser()

--- a/tests/workflows/test_workflows.py
+++ b/tests/workflows/test_workflows.py
@@ -7,7 +7,7 @@
 #
 #     monkeypatch.chdir(tmp_path)
 #     #save a turtle file
-#     with open("test.ttl",'w') as f:
+#     with open("test.ttl",'w', encoding="utf-8") as f:
 #         f.write(proc.serializeTurtle())
 #
 #     #save a DOT graph as PDF
@@ -20,7 +20,7 @@
 #
 #     monkeypatch.chdir(tmp_path)
 #     #save a turtle file
-#     with open("test.ttl", 'w') as f:
+#     with open("test.ttl", 'w', encoding="utf-8") as f:
 #         f.write(proc.serializeTurtle())
 #
 #     #save a DOT graph as PDF


### PR DESCRIPTION
Calling `open()` without an explicit encoding uses the OS encoding, which is not always sensible.  See [PEP 597](https://peps.python.org/pep-0597/) et alii.