### PR TITLE
Replace "type(x) is y" with "isinstance(x, y)"

### DIFF
--- a/src/nidm/experiment/Core.py
+++ b/src/nidm/experiment/Core.py
@@ -588,13 +588,12 @@ class Core:
             # context[key]['@id']= value.uri
 
             # context[key]['@type']='@id'
-            if isinstance(value.uri, str):
-                context[key] = value.uri
+
             # added for some weird namespaces where key is URIRef and value is Namespace
             # seems to only apply to PROV and NIDM qualified names.
             # has something to do with read_nidm function in Utils and add_metadata_for_subject
             # when it comes across a NIDM or PROV term.
-            elif isinstance(key, URIRef):
+            if isinstance(key, URIRef):
                 continue
             else:
                 context[key] = str(value.uri)

--- a/src/nidm/experiment/Core.py
+++ b/src/nidm/experiment/Core.py
@@ -132,13 +132,13 @@ class Core:
         )
 
     def getDataType(self, var):
-        if type(var) is int:
+        if isinstance(var, int):
             return pm.XSD_INTEGER
-        elif type(var) is float:
+        elif isinstance(var, float):
             return pm.XSD_FLOAT
-        elif type(var) is str:
+        elif isinstance(var, str):
             return pm.XSD_STRING
-        elif type(var) is list:
+        elif isinstance(var, list):
             return list
         else:
             print("datatype not found...")
@@ -588,13 +588,13 @@ class Core:
             # context[key]['@id']= value.uri
 
             # context[key]['@type']='@id'
-            if type(value.uri) is str:
+            if isinstance(value.uri, str):
                 context[key] = value.uri
             # added for some weird namespaces where key is URIRef and value is Namespace
             # seems to only apply to PROV and NIDM qualified names.
             # has something to do with read_nidm function in Utils and add_metadata_for_subject
             # when it comes across a NIDM or PROV term.
-            elif type(key) is URIRef:
+            elif isinstance(key, URIRef):
                 continue
             else:
                 context[key] = str(value.uri)

--- a/src/nidm/experiment/Navigate.py
+++ b/src/nidm/experiment/Navigate.py
@@ -118,7 +118,7 @@ def expandID(id, namespace):  # noqa: A002
     if id.find("http") < 0:
         return namespace[id]
     # it has a http, but isn't a URIRef so convert it
-    if type(id) is str:
+    if isinstance(id, str):
         return URIRef(id)
 
     return id

--- a/src/nidm/experiment/Query.py
+++ b/src/nidm/experiment/Query.py
@@ -137,7 +137,7 @@ def GetProjectsUUID(nidm_file_list, output_file=None):
     """
     df = sparql_query_nidm(nidm_file_list, query, output_file=output_file)
 
-    return df["uuid"] if type(df["uuid"]) is list else df["uuid"].tolist()
+    return df["uuid"] if isinstance(df["uuid"], list) else df["uuid"].tolist()
 
 
 def GetProjectLocation(nidm_file_list, project_uuid, output_file=None):  # noqa: U100

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -370,7 +370,7 @@ def addimagingsessions(
             if len(json_data.info) > 0:
                 for key in json_data.info.items():
                     if key in BIDS_Constants.json_keys:
-                        if type(json_data.info[key]) is list:
+                        if isinstance(json_data.info[key], list):
                             acq_obj.add_attributes(
                                 {
                                     BIDS_Constants.json_keys[
@@ -425,7 +425,7 @@ def addimagingsessions(
             for key in dataset:
                 # if key from T1w.json file is mapped to term in BIDS_Constants.py then add to NIDM object
                 if key in BIDS_Constants.json_keys:
-                    if type(dataset[key]) is list:
+                    if isinstance(dataset[key], list):
                         acq_obj.add_attributes(
                             {BIDS_Constants.json_keys[key]: "".join(dataset[key])}
                         )
@@ -524,7 +524,7 @@ def addimagingsessions(
             if len(json_data.info) > 0:
                 for key in json_data.info.items():
                     if key in BIDS_Constants.json_keys:
-                        if type(json_data.info[key]) is list:
+                        if isinstance(json_data.info[key], list):
                             acq_obj.add_attributes(
                                 {
                                     BIDS_Constants.json_keys[
@@ -628,7 +628,7 @@ def addimagingsessions(
             for key in dataset:
                 # if key from task-rest_bold.json file is mapped to term in BIDS_Constants.py then add to NIDM object
                 if key in BIDS_Constants.json_keys:
-                    if type(dataset[key]) is list:
+                    if isinstance(dataset[key], list):
                         acq_obj.add_attributes(
                             {
                                 BIDS_Constants.json_keys[key]: ",".join(
@@ -722,7 +722,7 @@ def addimagingsessions(
             if len(json_data.info) > 0:
                 for key in json_data.info.items():
                     if key in BIDS_Constants.json_keys:
-                        if type(json_data.info[key]) is list:
+                        if isinstance(json_data.info[key], list):
                             acq_obj.add_attributes(
                                 {
                                     BIDS_Constants.json_keys[
@@ -826,7 +826,7 @@ def addimagingsessions(
             if len(json_data.info) > 0:
                 for key in json_data.info.items():
                     if key in BIDS_Constants.json_keys:
-                        if type(json_data.info[key]) is list:
+                        if isinstance(json_data.info[key], list):
                             acq_obj.add_attributes(
                                 {
                                     BIDS_Constants.json_keys[
@@ -1018,7 +1018,7 @@ def bidsmri2project(directory, args):
                 project.add_attributes(
                     {BIDS_Constants.dataset_description[key]: "".join(dataset[key])}
                 )
-            elif type(dataset[key]) is list:
+            elif isinstance(dataset[key], list):
                 # 7/22/23 - modified to add attributes to collection of acquisition objects
                 collection.add_attributes(
                     {BIDS_Constants.dataset_description[key]: "".join(dataset[key])}

--- a/src/nidm/experiment/tools/rest.py
+++ b/src/nidm/experiment/tools/rest.py
@@ -46,7 +46,7 @@ class RestParser:
         def allUUIDs(arr):
             uuid_only = True
             for s in arr:
-                if type(s) is not str or not re.match(
+                if not isinstance(s, str) or not re.match(
                     "^[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+-[0-9a-f]+$", s
                 ):
                     uuid_only = False

--- a/src/nidm/experiment/tools/rest.py
+++ b/src/nidm/experiment/tools/rest.py
@@ -72,7 +72,7 @@ class RestParser:
             appendicies = []
             for key in result:
                 # format a list
-                if type(result[key]) is list:
+                if isinstance(result[key], list):
                     appendix = []
                     for line in result[key]:
                         appendix.append([json.dumps(line)])
@@ -83,11 +83,11 @@ class RestParser:
                         table.append([json.dumps(key), ",".join(result[key])])
 
                 # format a string
-                elif type(result[key]) is str:
+                elif isinstance(result[key], str):
                     table.append([json.dumps(key), result[key]])
 
                 # format a dictionary
-                elif type(result[key]) is dict:
+                elif isinstance(result[key], dict):
                     # put any dict into it's own table at the end (sort of like an appendix)
                     appendix = []
                     for inner_key in result[key]:
@@ -97,7 +97,7 @@ class RestParser:
                 # format anything else
                 else:
                     col1 = json.dumps(key)
-                    if type(result[key]) is set:
+                    if isinstance(result[key], set):
                         col2 = json.dumps(list(result[key]))
                     else:
                         col2 = json.dumps(result[key])
@@ -115,10 +115,10 @@ class RestParser:
                 rowInProgress = []
             for key in obj:
                 newrow = deepcopy(rowInProgress)
-                if depth < maxDepth and type(obj[key]) is dict:
+                if depth < maxDepth and isinstance(obj[key], dict):
                     newrow.append(key)
                     flatten(obj[key], maxDepth, table, newrow, depth + 1)
-                elif type(obj[key]) is str:
+                elif isinstance(obj[key], str):
                     newrow.append(key)
                     newrow.append(obj[key])
                     table.append(newrow)
@@ -319,9 +319,9 @@ class RestParser:
                     toptable.append([key, result[key]])
 
             for key in special_keys:
-                if type(result[key]) is dict:
+                if isinstance(result[key], dict):
                     toptable.append([key, ",".join(result[key].keys())])
-                elif type(result[key]) is list:
+                elif isinstance(result[key], list):
                     toptable.append([key, ",".join(result[key])])
                 else:
                     toptable.append([key, json.dumps(result[key])])
@@ -345,15 +345,15 @@ class RestParser:
 
             for key in special_keys:
                 if key in result:
-                    if type(result[key]) is dict:
+                    if isinstance(result[key], dict):
                         toptable.append([key, ",".join(result[key].keys())])
                     if (
-                        type(result[key]) is list
+                        isinstance(result[key], list)
                         and len(result[key]) > 0
-                        and type(result[key][0]) is Navigate.ActivityData
+                        and isinstance(result[key][0], Navigate.ActivityData)
                     ):
                         toptable.append([key, ",".join([x.uuid for x in result[key]])])
-                    elif type(result[key]) is list:
+                    elif isinstance(result[key], list):
                         toptable.append([key, ",".join])
                     else:
                         toptable.append([key, json.dumps(result[key])])
@@ -950,9 +950,9 @@ class RestParser:
             return json_str
 
         elif self.output_format == RestParser.CLI_FORMAT:
-            if type(result) is dict:
+            if isinstance(result, dict):
                 return self.dictFormat(result, headers)
-            if type(result) is list:
+            if isinstance(result, list):
                 return self.arrayFormat(result, headers)
             else:
                 return str(result)

--- a/src/nidm/experiment/tools/rest_statistics.py
+++ b/src/nidm/experiment/tools/rest_statistics.py
@@ -33,7 +33,7 @@ def GetProjectsComputedMetadata(nidm_file_list):
 
             for a in activities:
                 data = Navigate.getActivityData(tuple(nidm_file_list), a)
-                if type(data) is Navigate.ActivityData:
+                if isinstance(data, Navigate.ActivityData):
                     for x in data.data:
                         if x.isAbout == Constants.NIDM_IS_ABOUT_AGE:
                             if (

--- a/tests/experiment/test_experiment_basic.py
+++ b/tests/experiment/test_experiment_basic.py
@@ -68,7 +68,7 @@ def test_project_noparameters():
     proj = Project()
 
     # checking if we created ProvDocument
-    assert type(proj.bundle) is Constants.NIDMDocument
+    assert isinstance(proj.bundle, Constants.NIDMDocument)
     assert issubclass(type(proj.bundle), prov.model.ProvDocument)
 
     # checking graph namespace
@@ -89,7 +89,7 @@ def test_project_emptygraph():
     proj = Project(empty_graph=True)
 
     # checking if we created ProvDocument
-    assert type(proj.bundle) is Constants.NIDMDocument
+    assert isinstance(proj.bundle, Constants.NIDMDocument)
 
     # checking graph namespace
     namesp = [i.prefix for i in proj.graph.namespaces]
@@ -107,7 +107,7 @@ def test_project_uuid():
     proj = Project(uuid="my_uuid")
 
     # checking if we created ProvDocument
-    assert type(proj.bundle) is Constants.NIDMDocument
+    assert isinstance(proj.bundle, Constants.NIDMDocument)
     assert issubclass(type(proj.bundle), prov.model.ProvDocument)
 
     # checking graph namespace
@@ -133,7 +133,7 @@ def test_project_att():
     )
 
     # checking if we created ProvDocument
-    assert type(proj.bundle) is Constants.NIDMDocument
+    assert isinstance(proj.bundle, Constants.NIDMDocument)
     assert issubclass(type(proj.bundle), prov.model.ProvDocument)
 
     # checking graph namespace
@@ -157,7 +157,7 @@ def test_session_noparameters():
     Session(proj)
 
     # checking if we created ProvDocument
-    assert type(proj.bundle) is Constants.NIDMDocument
+    assert isinstance(proj.bundle, Constants.NIDMDocument)
     assert issubclass(type(proj.bundle), prov.model.ProvDocument)
 
     # checking if one session is added

--- a/tests/experiment/tools/test_rest.py
+++ b/tests/experiment/tools/test_rest.py
@@ -186,8 +186,8 @@ def test_uri_subject_list(brain_vol: BrainVol, openneuro: OpenNeuro) -> None:
     restParser = RestParser(output_format=RestParser.OBJECT_FORMAT)
     result = restParser.run(brain_vol.files + openneuro.files, "/subjects")
 
-    assert type(result) is dict
-    assert type(result["subject"]) is list
+    assert isinstance(result, dict)
+    assert isinstance(result["subject"], list)
     assert len(result["subject"]) > 10
 
 
@@ -199,15 +199,15 @@ def test_uri_subject_list_with_fields(
         brain_vol.files + openneuro.files,
         "/subjects?fields=ilx_0100400,MagneticFieldStrength",
     )  # ilx_0100400 "is about" age
-    assert type(result) is dict
+    assert isinstance(result, dict)
 
-    assert type(result["subject"]) is list
+    assert isinstance(result["subject"], list)
     assert len(result["subject"]) > 10
 
-    assert type(result["fields"]) is dict
+    assert isinstance(result["fields"], dict)
     all_fields = []
     for sub in result["fields"]:
-        assert type(result["fields"][sub]) is dict
+        assert isinstance(result["fields"][sub], dict)
         for activity in result["fields"][sub]:
             all_fields.append(result["fields"][sub][activity].label)
             if result["fields"][sub][activity].value != "n/a":
@@ -250,7 +250,7 @@ def test_uri_project_list(tmp_path: Path) -> None:
     for uuid_ in result:
         project_uuids.append(uuid_)
 
-    assert type(result) is list
+    assert isinstance(result, list)
     assert len(project_uuids) >= 2
     assert proj1_uuid in project_uuids
     assert proj2_uuid in project_uuids
@@ -276,7 +276,7 @@ def test_uri_projects_subjects_1(rest_test: RestTest) -> None:
     restParser = RestParser()
     result = restParser.run([rest_test.path], f"/projects/{proj_uuid}/subjects")
 
-    assert type(result) is dict
+    assert isinstance(result, dict)
     assert len(result["uuid"]) == 2
 
     assert rest_test.p2_subject_uuids[0] in result["uuid"]
@@ -290,7 +290,7 @@ def test_uri_subjects(brain_vol: BrainVol) -> None:
         brain_vol.files, f"/subjects/{brain_vol.cmu_test_subject_uuid}"
     )
 
-    assert type(result) is dict
+    assert isinstance(result, dict)
     assert "uuid" in result
     assert "instruments" in result
     assert "derivatives" in result
@@ -308,7 +308,7 @@ def test_uri_projects_subjects_id(openneuro: OpenNeuro) -> None:
     uri = f"/projects/{project}/subjects/{subject}"
     result = restParser.run(openneuro.files, uri)
 
-    assert type(result) is dict
+    assert isinstance(result, dict)
     assert result["uuid"] == subject
     assert len(result["instruments"]) > 2
 
@@ -663,7 +663,7 @@ def test_multiple_project_fields(brain_vol: BrainVol) -> None:
     # fv = project['field_values']
     print(fields)
     fv = fields
-    assert type(fv) is list
+    assert isinstance(fv, list)
     fields_used = {i.label for i in fv}
     assert ("brain" in fields_used) or (
         "Brain Segmentation Volume (mm^3)" in fields_used
@@ -685,7 +685,7 @@ def test_odd_isabout_uris(brain_vol: BrainVol) -> None:
     # fv = project['field_values']
     print(fields)
     fv = fields
-    assert type(fv) is list
+    assert isinstance(fv, list)
     fields_used = {i.label for i in fv}
     assert "ADOS_TOTAL" in fields_used
 
@@ -704,7 +704,7 @@ def test_project_fields_deriv(brain_vol: BrainVol) -> None:
     assert len(project) > 0
     # fv = project['field_values']
     fv = project
-    assert type(fv) is list
+    assert isinstance(fv, list)
     fields_used = {i.label for i in fv}
     assert ("brain" in fields_used) or (
         "Brain Segmentation Volume (mm^3)" in fields_used
@@ -727,7 +727,7 @@ def test_project_fields_instruments(brain_vol: BrainVol) -> None:
     assert len(project) > 0
     # fv = project['field_values']
     fv = project
-    assert type(fv) is list
+    assert isinstance(fv, list)
     fields_used = {i.label for i in fv}
     assert field in fields_used
 

--- a/tests/experiment/tools/test_rest_dataelements.py
+++ b/tests/experiment/tools/test_rest_dataelements.py
@@ -51,7 +51,7 @@ def test_dataelement_list(
     rest_parser = RestParser(output_format=RestParser.OBJECT_FORMAT)
     result = rest_parser.run(openneuro_files, "/dataelements")
 
-    assert type(result) is dict
+    assert isinstance(result, dict)
     assert "data_elements" in result
     assert "uuid" in result["data_elements"]
     assert "label" in result["data_elements"]
@@ -75,7 +75,7 @@ def test_dataelement_list(
 
     # now check for derivatives
     result = rest_parser.run(brain_vol_files, "/dataelements")
-    assert type(result) is dict
+    assert isinstance(result, dict)
     assert (
         "Left-WM-hypointensities Volume_mm3 (mm^3)" in result["data_elements"]["label"]
     )


### PR DESCRIPTION
Since `type` doesn't account for subclass inheritance at all, and likely in all those cases what matters is that an instance of that top level class. 

Spotted while having a pick at https://github.com/incf-nidash/PyNIDM/pull/385/files