### PR TITLE
Allow pyld 2.x series

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ install_requires =
     pybids >= 0.12.4
     pydot
     pygithub
-    pyld >= 1.0.5, <2.0
+    pyld >= 1.0.5, <3.0
     python-dateutil ~= 2.0
     rapidfuzz
     rdflib


### PR DESCRIPTION
Originally was ==1.0.5, then relaxed to be under 2.0. Current release 2.0.3 and I hope it would address some warnings