### PR TITLE
new version of release and publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+# This workflows will upload a Python Package using Twine when a release is created
+# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+
+name: Upload to PyPI
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '^3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build twine
+
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        python -m build
+        twine upload dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,48 +8,32 @@ on:
 jobs:
   auto-release:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'skip ci')"
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
-      - name: Download auto
-        run: |
-          curl -vL -o - "$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')" | gunzip > ~/auto
-          chmod a+x ~/auto
+      - name: Prepare repository
+        # Fetch full git history and tags
+        run: git fetch --unshallow --tags
 
-      - name: Check whether a release is due
-        id: auto-version
-        run: |
-          version="$(~/auto version)"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Unset header
+        # checkout@v2 adds a header that makes branch protection report errors
+        # because the Github action bot is not a collaborator on the repo
+        run: git config --local --unset http.https://github.com/.extraheader
 
       - name: Set up Python
-        if: steps.auto-version.outputs.version != ''
         uses: actions/setup-python@v5
         with:
           python-version: '^3.8'
 
-      - name: Install Python dependencies
-        if: steps.auto-version.outputs.version != ''
-        run: python -m pip install build twine
+      - name: Download auto
+        run: |
+          auto_download_url="$(curl -fsSL https://api.github.com/repos/intuit/auto/releases/latest | jq -r '.assets[] | select(.name == "auto-linux.gz") | .browser_download_url')"
+          wget -O- "$auto_download_url" | gunzip > ~/auto
+          chmod a+x ~/auto
 
       - name: Create release
-        if: steps.auto-version.outputs.version != ''
-        run: ~/auto shipit
+        run: |
+          ~/auto shipit -vv
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build & upload to PyPI
-        if: steps.auto-version.outputs.version != ''
-        run: |
-          python -m build
-          twine upload dist/*
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-
-# vim:set sts=2:


### PR DESCRIPTION
@dbkeator - i'm not completely sure why the workflow was not completing (it didn't raise an error, but it also didn't complete), perhaps there were using some older version of `auto`. 

I decided to update to the version that I have in other projects. I also created a separate workflow to publish the package to PyPI and I changed the authorization pattern - added `PYPI_API_TOKEN`.

I will try to create a new release and hopefully it will upload without issues