### PR TITLE
fixed bug in pynidm command line annotator

### DIFF
--- a/src/nidm/experiment/Utils.py
+++ b/src/nidm/experiment/Utils.py
@@ -528,15 +528,19 @@ def read_nidm(nidmDoc):
 
 
 def get_RDFliteral_type(rdf_literal):
-    if (rdf_literal.datatype == XSD["integer"]) or (rdf_literal.datatype == XSD["int"]):
-        # return (int(rdf_literal))
-        return pm.Literal(rdf_literal, datatype=pm.XSD["integer"])
-    elif rdf_literal.datatype in (XSD["float"], XSD["double"]):
-        # return(float(rdf_literal))
-        return pm.Literal(rdf_literal, datatype=pm.XSD["float"])
+    # If it's not already an rdflib Literal, convert it
+    if not isinstance(rdf_literal, Literal):
+        rdf_literal = Literal(rdf_literal)
+
+    # Now check the datatype
+    if rdf_literal.datatype in (XSD.integer, XSD.int):
+        return pm.Literal(int(rdf_literal), datatype=pm.XSD["integer"])
+    elif rdf_literal.datatype in (XSD.float, XSD.double):
+        return pm.Literal(float(rdf_literal), datatype=pm.XSD["float"])
+    elif rdf_literal.datatype == XSD.boolean:
+        return pm.Literal(bool(rdf_literal), datatype=pm.XSD["boolean"])
     else:
-        # return (str(rdf_literal))
-        return pm.Literal(rdf_literal, datatype=pm.XSD["string"])
+        return pm.Literal(str(rdf_literal), datatype=pm.XSD["string"])
 
 
 def find_in_namespaces(search_uri, namespaces):

--- a/src/nidm/experiment/tools/csv2nidm.py
+++ b/src/nidm/experiment/tools/csv2nidm.py
@@ -1188,7 +1188,12 @@ def csv2nidm_main(args=None):
             logging.info("Writing NIDM file....")
         else:
             print("Writing NIDM file....")
-        rdf_graph.serialize(destination=args.output_file, format="turtle")
+        # 5/7/25: added to accommodate the situation where user doesn't put .ttl at the end of the -out filename
+        if ".ttl" not in args.output_file:
+            output_file = args.output_file + ".ttl"
+        else:
+            output_file = args.output_file
+        rdf_graph.serialize(destination=output_file, format="turtle")
 
 
 if __name__ == "__main__":

--- a/src/nidm/experiment/tools/csv2nidm.py
+++ b/src/nidm/experiment/tools/csv2nidm.py
@@ -993,7 +993,7 @@ def csv2nidm_main(args=None):
                 # add metadata to der_entity
 
                 # store other data from row with columns_to_term mappings
-                for row_variable, row_data in csv_row.iteritems():
+                for row_variable, row_data in csv_row.items():
                     # check if row_variable is subject id, if so skip it
                     if (row_variable == id_field) or (
                         row_variable in ["ses", "task", "run"]
@@ -1001,11 +1001,7 @@ def csv2nidm_main(args=None):
                         continue
                     elif row_variable == "source_url":
                         der_entity.add_attributes(
-                            {
-                                Constants.PROV["Location"]: Identifier(
-                                    row_data["source_url"]
-                                )
-                            }
+                            {Constants.PROV["Location"]: Identifier(row_data)}
                         )
                     if str(row_data) != "nan":
                         # add data for this variable to derivative entity


### PR DESCRIPTION
Bug fixes:

- csv2nidm now adds .ttl extention to -out parameter if user didn't add it and not using an existing nidm file to add assessment data
- csv2nidm bug fixed when adding a source_url for derivative data
- pynidm annotation tools bug when trying to set the prov data type for literal values (e.g. 30, control, etc.) when those literal values haven't previously been converted to rdflib literal objects
