### PR TITLE
Fix participants.tsv whitespace in column headers, shared Project/Dataset UUIDs in per-subject mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -369,8 +369,15 @@ API key for your account.
 
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
 
+   # Write one NIDM file per subject (sub-<id>_nidm.ttl) into the BIDS directory:
+   $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject
+
+   # Or direct the per-subject files to a different output directory:
+   $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject -o [OUTPUT DIRECTORY]
+
    usage: bidsmri2nidm [-h] -d DIRECTORY [-jsonld] [-bidsignore] [-no_concepts]
                     [-json_map JSON_MAP] [-log LOGFILE] [-o OUTPUTFILE]
+                    [-per_subject]
 
    This program will represent a BIDS MRI dataset as a NIDM RDF document and provide user with opportunity to annotate
    the dataset (i.e. create sidecar files) and associate selected variables with broader concepts to make datasets more
@@ -389,7 +396,15 @@ API key for your account.
                         If flag set, tool will no do concept mapping
      -log LOGFILE, --log LOGFILE
                         Full path to directory to save log file. Log file name is bidsmri2nidm_[basename(args.directory)].log
-     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here
+     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here.
+                           In ``--per_subject`` mode this argument is interpreted as an output **directory** (created if missing)
+                           into which one ``sub-<id>_nidm.ttl`` file is written per subject.
+     -per_subject, --per_subject
+                        If flag set, a separate NIDM turtle file will be written for each subject in the BIDS directory,
+                        named ``sub-<id>_nidm.ttl``.  By default these are placed in the BIDS directory; use ``-o`` to
+                        specify a different output directory.  When combined with ``-bidsignore``, each per-subject file
+                        is appended to the BIDS dataset's ``.bidsignore`` file (only when the output directory lies
+                        inside the BIDS tree).
 
    map variables to terms arguments:
      -json_map JSON_MAP, --json_map JSON_MAP

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -367,8 +367,15 @@ API key for your account.
 
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
 
+   # Write one NIDM file per subject (sub-<id>_nidm.ttl) into the BIDS directory:
+   $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject
+
+   # Or direct the per-subject files to a different output directory:
+   $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject -o [OUTPUT DIRECTORY]
+
    usage: bidsmri2nidm [-h] -d DIRECTORY [-jsonld] [-bidsignore] [-no_concepts]
                     [-json_map JSON_MAP] [-log LOGFILE] [-o OUTPUTFILE]
+                    [-per_subject]
 
    This program will represent a BIDS MRI dataset as a NIDM RDF document and provide user with opportunity to annotate
    the dataset (i.e. create sidecar files) and associate selected variables with broader concepts to make datasets more
@@ -387,7 +394,15 @@ API key for your account.
                         If flag set, tool will no do concept mapping
      -log LOGFILE, --log LOGFILE
                         Full path to directory to save log file. Log file name is bidsmri2nidm_[basename(args.directory)].log
-     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here
+     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here.
+                           In ``--per_subject`` mode this argument is interpreted as an output **directory** (created if missing)
+                           into which one ``sub-<id>_nidm.ttl`` file is written per subject.
+     -per_subject, --per_subject
+                        If flag set, a separate NIDM turtle file will be written for each subject in the BIDS directory,
+                        named ``sub-<id>_nidm.ttl``.  By default these are placed in the BIDS directory; use ``-o`` to
+                        specify a different output directory.  When combined with ``-bidsignore``, each per-subject file
+                        is appended to the BIDS dataset's ``.bidsignore`` file (only when the output directory lies
+                        inside the BIDS tree).
 
    map variables to terms arguments:
      -json_map JSON_MAP, --json_map JSON_MAP

--- a/src/nidm/experiment/Utils.py
+++ b/src/nidm/experiment/Utils.py
@@ -825,7 +825,8 @@ def add_export_provenance(
     timestamp = datetime.now(timezone.utc).isoformat()
     python_version = platform.python_version()
     output_basename = os.path.basename(outputfile)
-    tool_label = script_name.removesuffix(".py")  # e.g. "bidsmri2nidm"
+    # str.removesuffix() is Python 3.9+; use a compatible alternative for 3.8 support
+    tool_label = script_name[:-3] if script_name.endswith(".py") else script_name
 
     rdf_graph.add((export_activity, RDF.type, prov_ns["Activity"]))
     rdf_graph.add((export_activity, rdfs_ns["label"], Literal(activity_label)))

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -199,13 +199,22 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
                 directory,
             )
 
+        # Pre-generate shared identifiers so every per-subject file references
+        # the same nidm:Project activity and the same bids:Dataset collection.
+        shared_project_uuid = getUUID()
+        shared_dataset_uuid = getUUID()
+
         subjects = bids.BIDSLayout(directory).get_subjects()
         for subj in subjects:
             if subj.startswith("."):
                 continue
             logging.info("Building NIDM file for subject %s", subj)
             project, collection, cde, cde_pheno = bidsmri2project(
-                directory, args, subject_filter=subj
+                directory,
+                args,
+                subject_filter=subj,
+                project_uuid=shared_project_uuid,
+                dataset_uuid=shared_dataset_uuid,
             )
             outputfile = os.path.join(out_dir, "sub-" + subj + "_nidm.ttl")
 
@@ -1028,7 +1037,16 @@ def _write_nidm_graph(
     rdf_graph.serialize(destination=outputfile, format="turtle")
 
 
-def bidsmri2project(directory, args, subject_filter=None):
+def bidsmri2project(
+    directory, args, subject_filter=None, project_uuid=None, dataset_uuid=None
+):
+    """Build a NIDM Project and BIDS Dataset collection from a BIDS directory.
+
+    When ``project_uuid`` and/or ``dataset_uuid`` are provided, the corresponding
+    UUIDs are used instead of newly generated ones.  This is used by
+    ``--per_subject`` mode so that every per-subject NIDM file references the
+    same ``nidm:Project`` activity and the same ``bids:Dataset`` collection.
+    """
     # initialize empty cde graph...it may get replaced if we're doing variable to term mapping or not
     cde = Graph()
 
@@ -1051,13 +1069,19 @@ def bidsmri2project(directory, args, subject_filter=None):
         sys.exit(-1)
 
     # create project / nidm-exp doc
-    project = Project()
+    # reuse caller-supplied UUID if provided (used by --per_subject mode so all
+    # per-subject files reference the same nidm:Project)
+    project = Project(uuid=project_uuid) if project_uuid is not None else Project()
 
     # 7/22/23 - Modified to create collection of AcquisitionObjects (prov:Entity) to
     # essentially model the BIDS dataset that we're using to convert data into the
     # NIDM representation
     provgraph = project.getGraph()
-    collection = provgraph.collection(Constants.NIIRI[getUUID()])
+    # reuse caller-supplied UUID if provided so the bids:Dataset is the same
+    # across per-subject files
+    collection = provgraph.collection(
+        Constants.NIIRI[dataset_uuid if dataset_uuid is not None else getUUID()]
+    )
     # 7/22/23 add type as bids:Dataset
     collection.add_attributes(
         {PROV_TYPE: QualifiedName(Namespace("bids", Constants.BIDS), "Dataset")}

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -145,6 +145,15 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
         default="nidm.ttl",
         help="Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here",
     )
+    parser.add_argument(
+        "-per_subject",
+        "--per_subject",
+        action="store_true",
+        default=False,
+        help="If flag set, a separate NIDM turtle file will be written for each subject in the BIDS "
+        "directory, named sub-<id>_nidm.ttl.  By default these are written into the BIDS directory; "
+        "use -o to specify a different output directory (it will be created if it does not exist).",
+    )
 
     args = parser.parse_args()
     directory = args.directory
@@ -165,52 +174,75 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
     # importlib.reload(sys)
     # sys.setdefaultencoding('utf8')
 
-    project, collection, cde, cde_pheno = bidsmri2project(directory, args)
+    if args.per_subject:
+        # discover subjects from BIDS layout and write one NIDM file per subject
+        bids.config.set_option("extension_initial_dot", True)
 
-    #  convert to rdflib Graph and add CDEs
-    rdf_graph = Graph()
-    rdf_graph.parse(source=StringIO(project.serializeTurtle()), format="turtle")
-    rdf_graph = rdf_graph + cde
+        # determine output directory: default to BIDS directory, else use -o as a directory
+        if args.outputfile == "nidm.ttl":
+            out_dir = directory
+        else:
+            out_dir = args.outputfile
+            if not os.path.isdir(out_dir):
+                os.makedirs(out_dir, exist_ok=True)
 
-    # add rest of phenotype CDEs
-    for entry in cde_pheno:
-        rdf_graph = rdf_graph + entry
+        # .bidsignore entries are paths relative to the BIDS root; only meaningful
+        # when output goes into the BIDS tree
+        abs_bids = os.path.abspath(directory)
+        abs_out = os.path.abspath(out_dir)
+        out_inside_bids = abs_out == abs_bids or abs_out.startswith(abs_bids + os.sep)
+        if args.bidsignore and not out_inside_bids:
+            logging.warning(
+                "Output directory %s is outside BIDS directory %s; per-subject "
+                "files will not be added to .bidsignore",
+                out_dir,
+                directory,
+            )
 
-    logging.info("Writing NIDM file....")
+        subjects = bids.BIDSLayout(directory).get_subjects()
+        for subj in subjects:
+            if subj.startswith("."):
+                continue
+            logging.info("Building NIDM file for subject %s", subj)
+            project, collection, cde, cde_pheno = bidsmri2project(
+                directory, args, subject_filter=subj
+            )
+            outputfile = os.path.join(out_dir, "sub-" + subj + "_nidm.ttl")
 
-    #  logging.info(project.serializeTurtle())
+            if args.bidsignore and out_inside_bids:
+                bidsignore_name = os.path.relpath(os.path.abspath(outputfile), abs_bids)
+            else:
+                bidsignore_name = None
 
-    logging.info("Serializing NIDM graph and creating graph visualization..")
-    # serialize graph
-
-    # if args.outputfile was defined by user then use it else use default which is args.directory/nidm.ttl
-    if args.outputfile == "nidm.ttl":
-        outputfile = os.path.join(directory, args.outputfile)
+            _write_nidm_graph(
+                project=project,
+                collection=collection,
+                cde=cde,
+                cde_pheno=cde_pheno,
+                outputfile=outputfile,
+                bidsignore=bidsignore_name is not None,
+                directory=directory,
+                bidsignore_name=bidsignore_name,
+            )
     else:
-        outputfile = args.outputfile
+        project, collection, cde, cde_pheno = bidsmri2project(directory, args)
 
-    # if we're choosing json-ld, make sure file extension is .json
-    # if args.jsonld:
-    #     outputfile=os.path.join(directory,os.path.splitext(args.outputfile)[0]+".json")
-    # if flag set to add to .bidsignore then add
-    #     if (args.bidsignore):
-    #         addbidsignore(directory,os.path.splitext(args.outputfile)[0]+".json")
+        # if args.outputfile was defined by user then use it else use default which is args.directory/nidm.ttl
+        if args.outputfile == "nidm.ttl":
+            outputfile = os.path.join(directory, args.outputfile)
+        else:
+            outputfile = args.outputfile
 
-    if args.bidsignore:
-        addbidsignore(directory, args.outputfile)
-
-    rdf_graph = add_export_provenance(
-        rdf_graph=rdf_graph,
-        collection=collection,
-        outputfile=outputfile,
-        pynidm_version=pynidm_version,
-        tool_version=__version__,
-        script_name="bidsmri2nidm.py",
-        activity_label="Create NIDM RDF from BIDS dataset",
-        output_format="turtle",
-    )
-
-    rdf_graph.serialize(destination=outputfile, format="turtle")
+        _write_nidm_graph(
+            project=project,
+            collection=collection,
+            cde=cde,
+            cde_pheno=cde_pheno,
+            outputfile=outputfile,
+            bidsignore=args.bidsignore,
+            directory=directory,
+            bidsignore_name=args.outputfile,
+        )
 
     # serialize NIDM file
     # with open(outputfile,'w', encoding="utf-8") as f:
@@ -960,7 +992,43 @@ def addimagingsessions(
             # link bval and bvec acquisition object entities together or is their association with DWI scan...
 
 
-def bidsmri2project(directory, args):
+def _write_nidm_graph(
+    project,
+    collection,
+    cde,
+    cde_pheno,
+    outputfile,
+    bidsignore,
+    directory,
+    bidsignore_name=None,
+):
+    """Build the rdflib Graph from the project/CDEs, add export provenance, and serialize to outputfile."""
+    rdf_graph = Graph()
+    rdf_graph.parse(source=StringIO(project.serializeTurtle()), format="turtle")
+    rdf_graph = rdf_graph + cde
+    for entry in cde_pheno:
+        rdf_graph = rdf_graph + entry
+
+    logging.info("Writing NIDM file %s ....", outputfile)
+
+    if bidsignore:
+        addbidsignore(directory, bidsignore_name or os.path.basename(outputfile))
+
+    rdf_graph = add_export_provenance(
+        rdf_graph=rdf_graph,
+        collection=collection,
+        outputfile=outputfile,
+        pynidm_version=pynidm_version,
+        tool_version=__version__,
+        script_name="bidsmri2nidm.py",
+        activity_label="Create NIDM RDF from BIDS dataset",
+        output_format="turtle",
+    )
+
+    rdf_graph.serialize(destination=outputfile, format="turtle")
+
+
+def bidsmri2project(directory, args, subject_filter=None):
     # initialize empty cde graph...it may get replaced if we're doing variable to term mapping or not
     cde = Graph()
 
@@ -1090,6 +1158,9 @@ def bidsmri2project(directory, args):
                     subjid = temp[1]
                 else:
                     subjid = temp[0]
+                # when per-subject mode is in use, skip rows for other subjects
+                if subject_filter is not None and subjid != subject_filter:
+                    continue
                 logging.info(subjid)
                 # add session and keep track if it for later using subjid
                 session[subjid] = Session(project)
@@ -1245,8 +1316,12 @@ def bidsmri2project(directory, args):
                         )
 
     # create acquisition objects for each scan for each subject
-    # loop through all subjects in dataset
-    for subject_id in bids_layout.get_subjects():
+    # loop through all subjects in dataset (or only the requested one in per-subject mode)
+    if subject_filter is not None:
+        subjects_to_process = [subject_filter]
+    else:
+        subjects_to_process = bids_layout.get_subjects()
+    for subject_id in subjects_to_process:
         logging.info("Converting subject: %s", subject_id)
         # skip .git directories...added to support datalad datasets
         if subject_id.startswith("."):
@@ -1333,6 +1408,9 @@ def bidsmri2project(directory, args):
 
             for row in pheno_data:
                 subjid = row["participant_id"].split("-")
+                # when per-subject mode is in use, skip phenotype rows for other subjects
+                if subject_filter is not None and subjid[1] != subject_filter:
+                    continue
                 # add acquisition object
                 acq = AssessmentAcquisition(session=session[subjid[1]])
                 # add qualified association with person

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -1129,6 +1129,11 @@ def bidsmri2project(
             os.path.join(directory, "participants.tsv"), encoding=encoding
         ) as csvfile:
             participants_data = csv.DictReader(csvfile, delimiter="\t")
+            # Strip leading/trailing whitespace from column names to handle TSV files
+            # where headers have accidental surrounding spaces (e.g. "age_at_scan ").
+            participants_data.fieldnames = [
+                f.strip() for f in participants_data.fieldnames
+            ]
 
             # logic to create data dictionaries for variables and/or use them if they already exist.
             # first iterate over variables in dataframe and check which ones are already mapped as BIDS constants
@@ -1394,6 +1399,8 @@ def bidsmri2project(
         encoding = check_encoding(tsv_file)
         with open(tsv_file, encoding=encoding) as phenofile:
             pheno_data = csv.DictReader(phenofile, delimiter="\t")
+            # Strip leading/trailing whitespace from column names (same defence as participants.tsv).
+            pheno_data.fieldnames = [f.strip() for f in pheno_data.fieldnames]
             mapping_list = []
             column_to_terms = {}
             for field in pheno_data.fieldnames:

--- a/tests/experiment/tools/test_bidsmri2nidm.py
+++ b/tests/experiment/tools/test_bidsmri2nidm.py
@@ -1,0 +1,242 @@
+"""
+Tests for bidsmri2nidm.py
+
+Focuses on edge cases in how participants.tsv (and phenotype/*.tsv) column
+headers are handled.  These tests do not require network access and run
+entirely from a synthetic BIDS directory built in a pytest tmp_path.
+"""
+
+from __future__ import annotations
+import argparse
+from io import StringIO
+import json
+from pathlib import Path
+from rdflib import Graph
+from rdflib.namespace import Namespace
+from nidm.experiment.tools.bidsmri2nidm import bidsmri2project
+
+# ---------------------------------------------------------------------------
+# Shared BIDS sidecar annotations (no interactive prompts, no network calls)
+# ---------------------------------------------------------------------------
+
+_PARTICIPANTS_SIDECAR = {
+    "age_at_scan": {
+        "description": "Age at anatomical scan in years",
+        "source_variable": "age_at_scan",
+        "associatedWith": "NIDM",
+        "valueType": "http://www.w3.org/2001/XMLSchema#float",
+        "minValue": "0",
+        "maxValue": "120",
+    },
+    "sex": {
+        "description": "Biological sex of participant",
+        "source_variable": "sex",
+        "associatedWith": "NIDM",
+        "valueType": "http://www.w3.org/2001/XMLSchema#complexType",
+    },
+}
+
+
+def _make_minimal_bids(root: Path, participants_tsv_text: str) -> None:
+    """Write the minimal files needed by bidsmri2project."""
+    (root / "dataset_description.json").write_text(
+        json.dumps({"Name": "TSV whitespace test", "BIDSVersion": "1.8.0"}),
+        encoding="utf-8",
+    )
+    (root / "participants.tsv").write_text(participants_tsv_text, encoding="utf-8")
+    # Pre-written BIDS sidecar so map_variables_to_terms needs no user input.
+    # Keys here intentionally use the *clean* (stripped) variable names.
+    (root / "participants.json").write_text(
+        json.dumps(_PARTICIPANTS_SIDECAR), encoding="utf-8"
+    )
+
+
+def _default_args(directory: str) -> argparse.Namespace:
+    return argparse.Namespace(
+        directory=directory,
+        json_map=False,
+        no_concepts=True,  # no network calls / interactive mapping
+        bidsignore=False,
+        outputfile="nidm.ttl",
+        logfile=None,
+    )
+
+
+def _to_rdflib(project, cde: Graph) -> Graph:
+    """Merge the prov project graph and CDE graph into a single rdflib Graph."""
+    g = Graph()
+    g.parse(source=StringIO(project.serializeTurtle()), format="turtle")
+    return g + cde
+
+
+NIDM = Namespace("http://purl.org/nidash/nidm#")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestParticipantsTsvWhitespaceStripping:
+    """
+    Regression tests for the fix that strips leading/trailing whitespace from
+    TSV column headers.  Prior to the fix, a header like 'age_at_scan ' (with
+    a trailing space) would silently fail to match the pre-written sidecar
+    entry 'age_at_scan', causing subject data to be lost.
+    """
+
+    def test_trailing_space_column_has_source_variable_stripped(
+        self, tmp_path: Path
+    ) -> None:
+        """
+        A column header with a trailing space ('age_at_scan ') must be stored
+        in the NIDM graph as nidm:sourceVariable "age_at_scan" (no space).
+        """
+        _make_minimal_bids(
+            tmp_path,
+            "participant_id\tage_at_scan \tsex\n"  # <-- trailing space in header
+            "sub-01\t25\t1\n"
+            "sub-02\t30\t2\n",
+        )
+        project, _, cde, _ = bidsmri2project(
+            str(tmp_path), _default_args(str(tmp_path))
+        )
+        g = _to_rdflib(project, cde)
+        ttl = g.serialize(format="turtle")
+
+        assert 'nidm:sourceVariable "age_at_scan"' in ttl, (
+            "Expected nidm:sourceVariable to be 'age_at_scan' (stripped), "
+            "but it was missing or still had the trailing space."
+        )
+        assert (
+            'nidm:sourceVariable "age_at_scan "' not in ttl
+        ), "nidm:sourceVariable should NOT contain the raw spaced name 'age_at_scan '."
+
+    def test_trailing_space_column_data_written_not_lost(self, tmp_path: Path) -> None:
+        """
+        When the header has a trailing space, subject data must still be
+        written into the NIDM graph (i.e. the value must not be silently
+        dropped or appear only as 'n/a').
+        """
+        _make_minimal_bids(
+            tmp_path,
+            "participant_id\tage_at_scan \tsex\n"  # <-- trailing space in header
+            "sub-01\t25\t1\n"
+            "sub-02\t30\t2\n",
+        )
+        project, _, cde, _ = bidsmri2project(
+            str(tmp_path), _default_args(str(tmp_path))
+        )
+        g = _to_rdflib(project, cde)
+        ttl = g.serialize(format="turtle")
+
+        # At least one of the age values must be present in the output.
+        assert '"25"' in ttl or '"25.0"' in ttl or '"30"' in ttl or '"30.0"' in ttl, (
+            "Expected age values (25 or 30) to appear in the NIDM output.  "
+            "This would be absent if the spaced column header caused a mismatch "
+            "against the sidecar and silently dropped the data."
+        )
+
+    def test_leading_space_column_stripped(self, tmp_path: Path) -> None:
+        """
+        A column header with a *leading* space (' age_at_scan') is also stripped.
+        """
+        _make_minimal_bids(
+            tmp_path,
+            "participant_id\t age_at_scan\tsex\n"  # <-- leading space in header
+            "sub-01\t25\t1\n"
+            "sub-02\t30\t2\n",
+        )
+        project, _, cde, _ = bidsmri2project(
+            str(tmp_path), _default_args(str(tmp_path))
+        )
+        g = _to_rdflib(project, cde)
+        ttl = g.serialize(format="turtle")
+
+        assert (
+            'nidm:sourceVariable "age_at_scan"' in ttl
+        ), "Leading-space column header should be stripped to 'age_at_scan'."
+        assert 'nidm:sourceVariable " age_at_scan"' not in ttl
+
+    def test_clean_column_unaffected(self, tmp_path: Path) -> None:
+        """
+        Columns without surrounding whitespace continue to work correctly
+        (non-regression guard).
+        """
+        _make_minimal_bids(
+            tmp_path,
+            "participant_id\tage_at_scan\tsex\n"  # clean header, no spaces
+            "sub-01\t25\t1\n"
+            "sub-02\t30\t2\n",
+        )
+        project, _, cde, _ = bidsmri2project(
+            str(tmp_path), _default_args(str(tmp_path))
+        )
+        g = _to_rdflib(project, cde)
+        ttl = g.serialize(format="turtle")
+
+        assert (
+            'nidm:sourceVariable "age_at_scan"' in ttl
+        ), "Clean column name should still produce the correct sourceVariable."
+
+
+class TestPhenotypeTsvWhitespaceStripping:
+    """
+    The same whitespace stripping applies to phenotype/*.tsv files.
+    """
+
+    def test_phenotype_tsv_trailing_space_stripped(self, tmp_path: Path) -> None:
+        """
+        A phenotype TSV column with a trailing space must be stripped before
+        the column name is stored as nidm:sourceVariable in the CDE graph.
+        """
+        _make_minimal_bids(
+            tmp_path,
+            # participants.tsv intentionally minimal; phenotype has the spaced col
+            "participant_id\n" "sub-01\n" "sub-02\n",
+        )
+        # Remove participants.json so map_variables_to_terms gets an empty list
+        (tmp_path / "participants.json").unlink(missing_ok=True)
+
+        # Build phenotype directory with spaced header
+        pheno_dir = tmp_path / "phenotype"
+        pheno_dir.mkdir()
+        (pheno_dir / "cognitive.tsv").write_text(
+            "participant_id\tiq_score \n"  # <-- trailing space in header
+            "sub-01\t110\n"
+            "sub-02\t95\n",
+            encoding="utf-8",
+        )
+        (pheno_dir / "cognitive.json").write_text(
+            json.dumps(
+                {
+                    "iq_score": {
+                        "description": "Full-scale IQ score",
+                        "source_variable": "iq_score",
+                        "associatedWith": "NIDM",
+                        "valueType": "http://www.w3.org/2001/XMLSchema#float",
+                        "minValue": "0",
+                        "maxValue": "200",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        project, _, cde, cde_pheno = bidsmri2project(
+            str(tmp_path), _default_args(str(tmp_path))
+        )
+
+        # Merge all CDE graphs
+        g = _to_rdflib(project, cde)
+        for cde_p in cde_pheno:
+            g = g + cde_p
+        ttl = g.serialize(format="turtle")
+
+        assert 'nidm:sourceVariable "iq_score"' in ttl, (
+            "Phenotype column 'iq_score ' (trailing space) should be stripped to "
+            "'iq_score' in the NIDM output."
+        )
+        assert (
+            'nidm:sourceVariable "iq_score "' not in ttl
+        ), "Spaced phenotype column name should not appear in the NIDM output."

--- a/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
+++ b/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import subprocess
 import sys
 import pytest
-from rdflib import Graph
+from rdflib import RDF, Graph
+from rdflib.namespace import Namespace
+
+NIDM = Namespace("http://purl.org/nidash/nidm#")
+BIDS = Namespace("http://bids.neuroimaging.io/")
 
 
 def _make_minimal_bids(root: Path, subjects: list[str]) -> None:
@@ -149,3 +153,46 @@ def test_per_subject_creates_missing_output_directory(
     assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
     assert out_dir.is_dir()
     assert len(list(out_dir.glob("sub-*_nidm.ttl"))) == 3
+
+
+def test_per_subject_files_share_project_and_dataset_uris(
+    tmp_path: Path, minimal_bids: Path
+) -> None:
+    """All per-subject NIDM files should reference the same nidm:Project and
+    bids:Dataset URIs so that cross-file SPARQL queries can recognize the
+    files as belonging to the same study and dataset."""
+    out_dir = tmp_path / "nidm_out"
+    out_dir.mkdir()
+
+    result = _run_bidsmri2nidm(
+        [
+            "-d",
+            str(minimal_bids),
+            "--per_subject",
+            "-o",
+            str(out_dir),
+            "--no_concepts",
+        ]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+
+    project_uris: set = set()
+    dataset_uris: set = set()
+    for ttl in sorted(out_dir.glob("sub-*_nidm.ttl")):
+        g = Graph()
+        g.parse(ttl, format="turtle")
+        # nidm:Project — the project activity
+        projects = set(g.subjects(RDF.type, NIDM.Project))
+        assert projects, f"no nidm:Project found in {ttl.name}"
+        project_uris.update(projects)
+        # bids:Dataset — the collection that holds the BIDS-side entities
+        datasets = set(g.subjects(RDF.type, BIDS.Dataset))
+        assert datasets, f"no bids:Dataset found in {ttl.name}"
+        dataset_uris.update(datasets)
+
+    assert (
+        len(project_uris) == 1
+    ), f"per-subject files reference {len(project_uris)} distinct nidm:Project URIs; expected 1"
+    assert (
+        len(dataset_uris) == 1
+    ), f"per-subject files reference {len(dataset_uris)} distinct bids:Dataset URIs; expected 1"

--- a/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
+++ b/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
@@ -1,0 +1,151 @@
+"""Tests for bidsmri2nidm --per_subject mode."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+import subprocess
+import sys
+import pytest
+from rdflib import Graph
+
+
+def _make_minimal_bids(root: Path, subjects: list[str]) -> None:
+    """Lay down a minimum BIDS dataset that bidsmri2nidm can process without prompts."""
+    (root / "dataset_description.json").write_text(
+        json.dumps({"Name": "pynidm-test-ds", "BIDSVersion": "1.0.0"})
+    )
+    header = "participant_id\n"
+    rows = "".join(f"sub-{s}\n" for s in subjects)
+    (root / "participants.tsv").write_text(header + rows)
+    for s in subjects:
+        anat = root / f"sub-{s}" / "anat"
+        anat.mkdir(parents=True)
+        # Empty NIfTI placeholders are sufficient for pybids to discover the subject;
+        # bidsmri2nidm logs a warning and continues when it cannot hash the file.
+        (anat / f"sub-{s}_T1w.nii.gz").write_bytes(b"")
+
+
+def _run_bidsmri2nidm(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "nidm.experiment.tools.bidsmri2nidm", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def minimal_bids(tmp_path: Path) -> Path:
+    bids = tmp_path / "bids"
+    bids.mkdir()
+    _make_minimal_bids(bids, ["01", "02", "03"])
+    return bids
+
+
+def test_per_subject_writes_one_file_per_subject(
+    tmp_path: Path, minimal_bids: Path
+) -> None:
+    out_dir = tmp_path / "nidm_out"
+    out_dir.mkdir()
+
+    result = _run_bidsmri2nidm(
+        [
+            "-d",
+            str(minimal_bids),
+            "--per_subject",
+            "-o",
+            str(out_dir),
+            "--no_concepts",
+        ]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+
+    produced = sorted(p.name for p in out_dir.glob("sub-*_nidm.ttl"))
+    assert produced == [
+        "sub-01_nidm.ttl",
+        "sub-02_nidm.ttl",
+        "sub-03_nidm.ttl",
+    ]
+
+
+def test_per_subject_files_parse_and_isolate_subject_ids(
+    tmp_path: Path, minimal_bids: Path
+) -> None:
+    out_dir = tmp_path / "nidm_out"
+    out_dir.mkdir()
+
+    result = _run_bidsmri2nidm(
+        [
+            "-d",
+            str(minimal_bids),
+            "--per_subject",
+            "-o",
+            str(out_dir),
+            "--no_concepts",
+        ]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+
+    subjects = ["01", "02", "03"]
+    for sid in subjects:
+        ttl = out_dir / f"sub-{sid}_nidm.ttl"
+        g = Graph()
+        g.parse(ttl, format="turtle")
+        assert len(g) > 0, f"sub-{sid}_nidm.ttl parsed but contains no triples"
+
+        text = ttl.read_text(encoding="utf-8")
+        assert f"sub-{sid}" in text, f"sub-{sid} missing from its own NIDM file"
+        for other in subjects:
+            if other == sid:
+                continue
+            assert (
+                f"sub-{other}" not in text
+            ), f"sub-{sid}_nidm.ttl unexpectedly references sub-{other}"
+
+
+def test_per_subject_defaults_to_bids_directory_and_updates_bidsignore(
+    minimal_bids: Path,
+) -> None:
+    # No -o, with -bidsignore: files should land in the BIDS dir and be listed
+    # in .bidsignore using paths relative to the BIDS root.
+    result = _run_bidsmri2nidm(
+        [
+            "-d",
+            str(minimal_bids),
+            "--per_subject",
+            "-bidsignore",
+            "--no_concepts",
+        ]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+
+    produced = sorted(p.name for p in minimal_bids.glob("sub-*_nidm.ttl"))
+    assert produced == [
+        "sub-01_nidm.ttl",
+        "sub-02_nidm.ttl",
+        "sub-03_nidm.ttl",
+    ]
+
+    bidsignore = (minimal_bids / ".bidsignore").read_text(encoding="utf-8")
+    for sid in ("01", "02", "03"):
+        assert f"sub-{sid}_nidm.ttl" in bidsignore
+
+
+def test_per_subject_creates_missing_output_directory(
+    tmp_path: Path, minimal_bids: Path
+) -> None:
+    out_dir = tmp_path / "does" / "not" / "exist"
+    assert not out_dir.exists()
+
+    result = _run_bidsmri2nidm(
+        [
+            "-d",
+            str(minimal_bids),
+            "--per_subject",
+            "-o",
+            str(out_dir),
+            "--no_concepts",
+        ]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+    assert out_dir.is_dir()
+    assert len(list(out_dir.glob("sub-*_nidm.ttl"))) == 3


### PR DESCRIPTION
## Summary

- **Strip leading/trailing whitespace from TSV column headers** in `bidsmri2nidm`.
  Some BIDS datasets (e.g. ABIDE-2 NYU site) have accidental surrounding spaces
  in `participants.tsv` column headers (e.g. `"age_at_scan "` with a trailing
  space). This caused a silent mismatch against the pre-written `participants.json`
  sidecar, resulting in subject data being lost (all values written as `"n/a"`
  instead of actual values). The fix calls `.strip()` on `DictReader.fieldnames`
  immediately after the reader is created, covering both `participants.tsv` and
  phenotype `/*.tsv` files.

- **Fix inconsistent Project and Dataset UUIDs in `--per_subject` mode**: when
  `bidsmri2nidm` was run with `--per_subject`, each per-subject NIDM file was
  assigned a fresh `nidm:Project` and `bids:Dataset` URI, making it impossible
  to join records across files with SPARQL. `bidsmri2project()` now accepts
  optional `project_uuid` and `dataset_uuid` parameters; the `--per_subject`
  loop pre-generates one UUID for each and reuses them across all per-subject
  files so every `sub-<id>_nidm.ttl` references the same project and dataset.
  Single-file mode is unchanged.


- **Add regression tests** in `tests/experiment/tools/test_bidsmri2nidm.py`
  covering trailing-space, leading-space, and clean column headers for both
  `participants.tsv` and phenotype TSV files; and verifying all per-subject files
  share exactly one Project URI and one Dataset URI.

## Test plan

- [ ] Run `pytest tests/experiment/tools/test_bidsmri2nidm.py` — all new tests pass
- [ ] Run full test suite — confirm Python 3.8, 3.9, 3.10, and 3.11 builds all pass on CI
- [ ] Re-run `bidsmri2nidm` on the ABIDE-2 NYU dataset and confirm `age_at_scan` now
      contains real values instead of `"n/a"` for all subjects
- [ ] Re-run `bidsmri2nidm --per_subject` on a multi-subject dataset and confirm all
      output files share the same `nidm:Project` and `bids:Dataset` URIs