### PR TITLE
Fix queryai 404 on retired Anthropic model; make model configurable

### DIFF
--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -627,6 +627,31 @@ def _extract_sparql(ai_response):
     return None
 
 
+def _ensure_prefixes(sparql_query, prefixes):
+    """Prepend ``PREFIX`` declarations for any prefix used in
+    *sparql_query* but not already declared, so the query is
+    self-contained / portable to external SPARQL engines (e.g. Stardog).
+
+    rdflib resolves undeclared prefixes from the graph's namespace
+    bindings at execution time, so queries run inside pynidm even without
+    a PREFIX block -- but they aren't portable.  *prefixes* is the
+    ``{prefix: uri}`` map from :func:`_extract_namespace_prefixes`.
+    """
+    declared = set(
+        re.findall(r"(?im)^\s*PREFIX\s+([A-Za-z][\w.\-]*)\s*:", sparql_query)
+    )
+    missing = [
+        p
+        for p, uri in prefixes.items()
+        if p not in declared
+        and re.search(rf"(?<![<\w]){re.escape(p)}:", sparql_query)
+    ]
+    if not missing:
+        return sparql_query
+    header = "\n".join(f"PREFIX {p}: <{prefixes[p]}>" for p in sorted(missing))
+    return header + "\n\n" + sparql_query
+
+
 def _execute_sparql(nidm_files, sparql_query):
     """Execute a SPARQL query against the loaded NIDM files."""
     g = Graph()
@@ -873,6 +898,10 @@ def queryai(nidm_file_list, question, output_file, show_query):
             )
             click.echo(f"AI response:\n{ai_response}", err=True)
             return
+
+        # Make the query self-contained: prepend any PREFIX declarations
+        # the AI omitted, so the shown/executed SPARQL is portable.
+        sparql_query = _ensure_prefixes(sparql_query, prefixes)
 
         if show_query:
             click.echo(f"\nGenerated SPARQL:\n{sparql_query}\n", err=True)

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -522,6 +522,13 @@ def _get_provider():
     return None
 
 
+# Anthropic model used for queryai.  Defaults to the current Claude
+# Sonnet (4.6); override via the PYNIDM_ANTHROPIC_MODEL env var so a
+# model deprecation doesn't require a code change.  (The previous
+# hard-coded "claude-sonnet-4-20250514" was retired and now 404s.)
+_ANTHROPIC_MODEL = os.environ.get("PYNIDM_ANTHROPIC_MODEL", "claude-sonnet-4-6")
+
+
 def _query_anthropic(system_prompt, user_question, api_key):
     """Send a query to the Anthropic API and return the response text."""
     try:
@@ -536,7 +543,7 @@ def _query_anthropic(system_prompt, user_question, api_key):
 
     client = anthropic.Anthropic(api_key=api_key)
     message = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model=_ANTHROPIC_MODEL,
         max_tokens=4096,
         system=system_prompt,
         messages=[{"role": "user", "content": user_question}],


### PR DESCRIPTION
pynidm queryai fails with anthropic.NotFoundError: 404 … model: claude-sonnet-4-20250514 because the model ID hardcoded in _query_anthropic (Claude Sonnet 4) has been retired by the Anthropic API.
Fix

Update the default model to the current Claude Sonnet (claude-sonnet-4-6), verified against Anthropic's [models overview](https://docs.claude.com/en/docs/about-claude/models/overview).
Make the model configurable via a new PYNIDM_ANTHROPIC_MODEL environment variable, so a future model deprecation can be worked around without a code change/release:

python  _ANTHROPIC_MODEL = os.environ.get("PYNIDM_ANTHROPIC_MODEL", "claude-sonnet-4-6")
  ...
  client.messages.create(model=_ANTHROPIC_MODEL, ...)
Files changed

src/nidm/experiment/tools/nidm_queryai.py — _query_anthropic model string + new env-var default.

Testing

Reproduced the original 404 with a valid API key on the old model ID.
Confirmed pynidm queryai -nl <file>.ttl -q "…" runs successfully with the new default, and that PYNIDM_ANTHROPIC_MODEL=<id> overrides it.

Notes

Only affects the Anthropic code path; the OpenAI (gpt-4o) path is unchanged.
No change to query logic or output — model selection only.
Users on the released package can unblock immediately with export PYNIDM_ANTHROPIC_MODEL=claude-sonnet-4-6 once on this version.