### PR TITLE
Fix multi-file SPARQL joins (-bv) & queryai CDE resolution; write per-subject bidsmri2nidm output in BIDS layout

### DIFF
--- a/src/nidm/experiment/Query.py
+++ b/src/nidm/experiment/Query.py
@@ -66,44 +66,31 @@ def sparql_query_nidm(nidm_file_list, query, output_file=None, return_graph=Fals
 
     logging.info("Query: %s", query)
 
-    first_file = True
-    # cycle through NIDM files, adding query result to list
+    # Merge all supplied NIDM files into a single graph and run the query once.
+    #
+    # Previously each file was opened and queried in isolation and the row
+    # results were concatenated.  That silently dropped any match whose graph
+    # pattern spanned more than one file -- e.g. measurement values stored in a
+    # NIDM file joined against the DataElement definitions (rdfs:label,
+    # nidm:measureOf, nidm:datumType, rdfs:subClassOf) stored in a separate CDE
+    # file.  Such queries (GetBrainVolumes / -bv, cross-file -q, etc.) returned
+    # nothing because neither file satisfied the full pattern on its own.
+    # Unioning the files first makes those cross-file joins resolve while
+    # leaving single-file and independent-per-file queries unchanged.
+    rdf_graph_parse = Graph()
     for nidm_file in nidm_file_list:
-        # project=read_nidm(nidm_file)
-        # read RDF file into temporary graph
-        # rdf_graph = Graph()
-        # rdf_graph_parse = rdf_graph.parse(nidm_file,format=util.guess_format(nidm_file))
-        rdf_graph_parse = OpenGraph(nidm_file)
+        rdf_graph_parse += OpenGraph(nidm_file)
 
-        if not return_graph:
-            # execute query
-            qres = rdf_graph_parse.query(query)
-
-            # if this is the first file then grab the SPARQL bound variable names from query result for column headings of query result
-            if first_file:
-                # format query result as dataframe and return
-                # for dicts in qres._get_bindings():
-                columns = [str(var) for var in qres.vars]
-                first_file = False
-                #    break
-
-            # append result as row to result list
-            for row in qres:
-                results.append(list(row))
-        else:
-            # execute query
-            qres = rdf_graph_parse.query(query)
-
-            if first_file:
-                # create graph
-                # WIP: qres_graph = Graph().parse(data=qres.serialize(format='turtle'))
-                qres_graph = qres.serialize(format="turtle")
-                first_file = False
-            else:
-                # WIP qres_graph = qres_graph + Graph().parse(data=qres.serialize(format='turtle'))
-                qres_graph = qres_graph + qres.serialize(format="turtle")
+    qres = rdf_graph_parse.query(query)
 
     if not return_graph:
+        # grab the SPARQL bound variable names for the dataframe column headings
+        columns = [str(var) for var in qres.vars]
+
+        # append each result row to the result list
+        for row in qres:
+            results.append(list(row))
+
         # convert results list to Pandas DataFrame and return
         df = pd.DataFrame(results, columns=columns)
 
@@ -112,7 +99,7 @@ def sparql_query_nidm(nidm_file_list, query, output_file=None, return_graph=Fals
             df.to_csv(output_file)
         return df
     else:
-        return qres_graph
+        return qres.serialize(format="turtle")
 
 
 def GetProjectsUUID(nidm_file_list, output_file=None):

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -150,9 +150,11 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
         "--per_subject",
         action="store_true",
         default=False,
-        help="If flag set, a separate NIDM turtle file will be written for each subject in the BIDS "
-        "directory, named sub-<id>_nidm.ttl.  By default these are written into the BIDS directory; "
-        "use -o to specify a different output directory (it will be created if it does not exist).",
+        help="If flag set, a separate NIDM turtle file named nidm.ttl will be written into each subject's "
+        "BIDS directory, i.e. BIDS_ROOT/sub-<id>/nidm.ttl.  By default these are written beneath the BIDS "
+        "directory; use -o to specify a different base output directory (sub-<id>/nidm.ttl is created "
+        "beneath it).  When combined with -bidsignore, each sub-<id>/nidm.ttl path is added to .bidsignore "
+        "so the dataset remains BIDS-valid.",
     )
 
     args = parser.parse_args()
@@ -216,9 +218,15 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
                 project_uuid=shared_project_uuid,
                 dataset_uuid=shared_dataset_uuid,
             )
-            outputfile = os.path.join(out_dir, "sub-" + subj + "_nidm.ttl")
+            # BIDS-friendly layout: write each subject's NIDM file into that
+            # subject's directory as nidm.ttl (i.e. BIDS_ROOT/sub-<id>/nidm.ttl)
+            # rather than a flat sub-<id>_nidm.ttl in the output root.
+            subj_dir = os.path.join(out_dir, "sub-" + subj)
+            os.makedirs(subj_dir, exist_ok=True)
+            outputfile = os.path.join(subj_dir, "nidm.ttl")
 
             if args.bidsignore and out_inside_bids:
+                # path relative to BIDS root, e.g. "sub-<id>/nidm.ttl"
                 bidsignore_name = os.path.relpath(os.path.abspath(outputfile), abs_bids)
             else:
                 bidsignore_name = None

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -82,6 +82,19 @@ def _extract_data_elements(nidm_files):
         for dt in g.objects(de, NIDM["datumType"]):
             entry["datum_type"] = str(dt)
 
+        # Pipeline DataElements (fsl:, freesurfer:, ants:, ...) describe the
+        # measured region/quantity with namespace-specific "structure" and
+        # "measure" predicates rather than nidm:sourceVariable.  Capture them so
+        # concept resolution can match phrasing like "left hippocampus volume"
+        # (structure="Left-Hippocampus", measure="Volume").  Matched generically
+        # by predicate local-name so it works across pipeline namespaces.
+        for p, o in g.predicate_objects(de):
+            plocal = str(p).rsplit("/", 1)[-1].rsplit("#", 1)[-1].lower()
+            if plocal == "structure" and "structure" not in entry:
+                entry["structure"] = str(o)
+            elif plocal == "measure" and "measure" not in entry:
+                entry["measure"] = str(o)
+
         data_elements.append(entry)
 
     return data_elements, g
@@ -173,9 +186,14 @@ def _resolve_concept(concept_name, data_elements, concept_hints=None):
         label = de.get("label", "").lower()
         src_var = de.get("source_variable", "").lower()
         is_about = de.get("is_about", "").lower()
+        # Pipeline DataElements carry the region/quantity in structure/measure
+        # (e.g. "Left-Hippocampus" / "Volume") instead of a sourceVariable, so
+        # include them so phrases like "left hippocampus volume" resolve.
+        structure = de.get("structure", "").lower()
+        measure = de.get("measure", "").lower()
 
-        # Check label and source_variable for keyword matches
-        text = f"{label} {src_var} {is_about}"
+        # Check label, source_variable, isAbout, structure and measure
+        text = f"{label} {src_var} {is_about} {structure} {measure}"
         if all(kw in text for kw in keywords):
             # If laterality is specified, filter on it
             if laterality:

--- a/tests/experiment/test_query.py
+++ b/tests/experiment/test_query.py
@@ -374,3 +374,54 @@ def test_custom_data_types():
     assert str(valuetype3["label"]) == "age"
     assert str(valuetype3["description"]) == "Age of participant at scan"
     assert str(valuetype3["isAbout"]) == str(Constants.NIIRI["24d78sq"])
+
+
+def test_sparql_query_nidm_merges_files_for_cross_file_join(tmp_path: Path) -> None:
+    """Regression test: sparql_query_nidm must union all supplied files into a
+    single graph so that a query whose pattern spans more than one file (e.g. a
+    measurement value in one file joined to its DataElement definition in a
+    separate CDE file) resolves.  Previously each file was queried in isolation
+    and the row results concatenated, so such cross-file joins returned nothing.
+    """
+    # File 1: a measurement value attached to an entity (no DataElement def).
+    values_ttl = (
+        "@prefix prov: <http://www.w3.org/ns/prov#> .\n"
+        "@prefix ex: <http://example.org/de#> .\n"
+        "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\n"
+        "<http://example.org/entity1> a prov:Entity ;\n"
+        '    ex:de_0001 "4235.0"^^xsd:float .\n'
+    )
+    # File 2: the DataElement definition only (no values).
+    defs_ttl = (
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n"
+        "@prefix nidm: <http://purl.org/nidash/nidm#> .\n"
+        "@prefix ex: <http://example.org/de#> .\n\n"
+        "ex:de_0001 a nidm:DataElement ;\n"
+        '    rdfs:label "Test Volume" .\n'
+    )
+    values_file = tmp_path / "values.ttl"
+    defs_file = tmp_path / "defs.ttl"
+    values_file.write_text(values_ttl, encoding="utf-8")
+    defs_file.write_text(defs_ttl, encoding="utf-8")
+
+    # Join spans both files: the value lives in values.ttl, the type+label of
+    # the predicate (DataElement) lives in defs.ttl.
+    query = """
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+        PREFIX nidm: <http://purl.org/nidash/nidm#>
+        SELECT ?label ?value WHERE {
+            ?entity ?de ?value .
+            ?de a nidm:DataElement ;
+                rdfs:label ?label .
+        }
+    """
+
+    # Neither file alone can satisfy the full pattern.
+    assert len(Query.sparql_query_nidm([str(values_file)], query)) == 0
+    assert len(Query.sparql_query_nidm([str(defs_file)], query)) == 0
+
+    # The merged graph does: one row with the label and value joined together.
+    df = Query.sparql_query_nidm([str(values_file), str(defs_file)], query)
+    assert len(df) == 1
+    assert str(df.iloc[0]["label"]) == "Test Volume"
+    assert float(df.iloc[0]["value"]) == 4235.0

--- a/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
+++ b/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
@@ -63,11 +63,13 @@ def test_per_subject_writes_one_file_per_subject(
     )
     assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
 
-    produced = sorted(p.name for p in out_dir.glob("sub-*_nidm.ttl"))
+    produced = sorted(
+        p.relative_to(out_dir).as_posix() for p in out_dir.glob("sub-*/nidm.ttl")
+    )
     assert produced == [
-        "sub-01_nidm.ttl",
-        "sub-02_nidm.ttl",
-        "sub-03_nidm.ttl",
+        "sub-01/nidm.ttl",
+        "sub-02/nidm.ttl",
+        "sub-03/nidm.ttl",
     ]
 
 
@@ -91,10 +93,10 @@ def test_per_subject_files_parse_and_isolate_subject_ids(
 
     subjects = ["01", "02", "03"]
     for sid in subjects:
-        ttl = out_dir / f"sub-{sid}_nidm.ttl"
+        ttl = out_dir / f"sub-{sid}" / "nidm.ttl"
         g = Graph()
         g.parse(ttl, format="turtle")
-        assert len(g) > 0, f"sub-{sid}_nidm.ttl parsed but contains no triples"
+        assert len(g) > 0, f"sub-{sid}/nidm.ttl parsed but contains no triples"
 
         text = ttl.read_text(encoding="utf-8")
         assert f"sub-{sid}" in text, f"sub-{sid} missing from its own NIDM file"
@@ -103,7 +105,7 @@ def test_per_subject_files_parse_and_isolate_subject_ids(
                 continue
             assert (
                 f"sub-{other}" not in text
-            ), f"sub-{sid}_nidm.ttl unexpectedly references sub-{other}"
+            ), f"sub-{sid}/nidm.ttl unexpectedly references sub-{other}"
 
 
 def test_per_subject_defaults_to_bids_directory_and_updates_bidsignore(
@@ -122,16 +124,19 @@ def test_per_subject_defaults_to_bids_directory_and_updates_bidsignore(
     )
     assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
 
-    produced = sorted(p.name for p in minimal_bids.glob("sub-*_nidm.ttl"))
+    produced = sorted(
+        p.relative_to(minimal_bids).as_posix()
+        for p in minimal_bids.glob("sub-*/nidm.ttl")
+    )
     assert produced == [
-        "sub-01_nidm.ttl",
-        "sub-02_nidm.ttl",
-        "sub-03_nidm.ttl",
+        "sub-01/nidm.ttl",
+        "sub-02/nidm.ttl",
+        "sub-03/nidm.ttl",
     ]
 
     bidsignore = (minimal_bids / ".bidsignore").read_text(encoding="utf-8")
     for sid in ("01", "02", "03"):
-        assert f"sub-{sid}_nidm.ttl" in bidsignore
+        assert f"sub-{sid}/nidm.ttl" in bidsignore
 
 
 def test_per_subject_creates_missing_output_directory(
@@ -152,7 +157,7 @@ def test_per_subject_creates_missing_output_directory(
     )
     assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
     assert out_dir.is_dir()
-    assert len(list(out_dir.glob("sub-*_nidm.ttl"))) == 3
+    assert len(list(out_dir.glob("sub-*/nidm.ttl"))) == 3
 
 
 def test_per_subject_files_share_project_and_dataset_uris(
@@ -178,7 +183,7 @@ def test_per_subject_files_share_project_and_dataset_uris(
 
     project_uris: set = set()
     dataset_uris: set = set()
-    for ttl in sorted(out_dir.glob("sub-*_nidm.ttl")):
+    for ttl in sorted(out_dir.glob("sub-*/nidm.ttl")):
         g = Graph()
         g.parse(ttl, format="turtle")
         # nidm:Project — the project activity


### PR DESCRIPTION
## Summary

Three related fixes that make FSL/FreeSurfer-style CDE data queryable and make
`bidsmri2nidm --per_subject` produce BIDS-valid output:

1. **`sparql_query_nidm` now merges all input files into one graph** before
   querying, instead of querying each file in isolation and concatenating rows.
2. **queryai resolves pipeline DataElements** (fsl:/freesurfer:/ants:) by
   indexing their `structure`/`measure` annotations.
3. **`bidsmri2nidm --per_subject` writes `BIDS_ROOT/sub-<id>/nidm.ttl`** instead
   of a flat `sub-<id>_nidm.ttl`, and registers those paths in `.bidsignore`.

## Background / motivation

Brain-volume data is split across files: the measurement *values* live in the
NIDM file (e.g. `fsl:fsl_000010 "4235.0"`), while the `DataElement` *definitions*
they join against (`rdfs:label`, `nidm:measureOf`, `nidm:datumType`,
`fsl:DataElement rdfs:subClassOf nidm:DataElement`) live in a separate CDE file.

- `pynidm query -nl nidm.ttl,fsl_cde.ttl -bv` returned **nothing**, because
  `sparql_query_nidm` ran the query against each file separately and
  concatenated the row results — so any pattern spanning two files matched in
  neither. (The same query against a single merged graph returns 18 rows.)
- `pynidm queryai … "left and right hippocampus volume"` dropped those variables
  in Phase 1. The resolver required every keyword to appear in
  `label + sourceVariable + isAbout`, but pipeline DEs have no `sourceVariable`
  and encode the region/quantity in `fsl:structure`/`fsl:measure`
  ("Left-Hippocampus" / "Volume"); "volume" appeared only in the un-indexed
  `measure`, so the match failed and the AI generated a query against a
  non-existent predicate.

## Changes

### `src/nidm/experiment/Query.py`
- `sparql_query_nidm` unions all files in `nidm_file_list` into a single graph
  and runs the query once. Single-file and independent-per-file queries are
  unaffected (the union is identical when no cross-file join exists); cross-file
  CDE joins (`GetBrainVolumes`/`-bv`, cross-file `-q`) now resolve. The
  `return_graph` path serializes from the merged graph.

### `src/nidm/experiment/tools/nidm_queryai.py`
- `_extract_data_elements` captures pipeline `structure`/`measure` literals
  (matched generically by predicate local-name, so it covers fsl/freesurfer/ants).
- `_resolve_concept` folds `structure`/`measure` into the matchable text, so
  "left hippocampus volume" → `fsl:fsl_000010`, "right …" → `fsl:fsl_000024`;
  voxel-count and wrong-laterality DEs are naturally excluded.

### `src/nidm/experiment/tools/bidsmri2nidm.py`
- `--per_subject` writes each subject's file to `BIDS_ROOT/sub-<id>/nidm.ttl`
  (creating the subject dir if needed) rather than a flat
  `BIDS_ROOT/sub-<id>_nidm.ttl`. `-o <dir>` still overrides the base directory
  (`<dir>/sub-<id>/nidm.ttl`).
- With `--bidsignore`, each `sub-<id>/nidm.ttl` (path relative to BIDS root) is
  added to `.bidsignore` so the dataset stays BIDS-valid.
- Help text updated to describe the new layout.

### `tests/experiment/test_query.py`
- Adds `test_sparql_query_nidm_merges_files_for_cross_file_join`: writes a value
  in one file and its DataElement definition in another, asserts each file alone
  yields 0 rows and the merged pair yields the joined row. Fails on the old
  per-file behavior, passes on the fix.

## Testing

- `pytest tests/` — 80 passed, 14 skipped.
- `pynidm query -nl nidm.ttl,fsl_cde.ttl -bv` now returns all 18 FSL volumes,
  including left (4235.0) and right (3190.0) hippocampus.
- `pynidm queryai … "age, sex, FIQ, and left and right hippocampus brain volume"`
  resolves all five variables and returns the joined per-subject row.
- `bidsmri2nidm --per_subject --bidsignore` verified on a real BIDS dataset:
  files land in `sub-<id>/nidm.ttl` and are listed in `.bidsignore`.

## Notes / follow-ups

- The `--per_subject` path is not yet covered by an automated test (verified
  manually); an end-to-end test is planned alongside mirroring this behavior
  into the LinkML `bidsmri2nidm`.
- A separate future improvement is hardening queryai's SPARQL-generation prompt
  (join by subject, prefer OPTIONAL, never FILTER over unbound variables).