### PR TITLE
bidsmri2nidm: write per-subject demographics when participant_id isn't zero-padded

### DIFF
--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -1213,9 +1213,26 @@ def bidsmri2project(
                     subjid = temp[1]
                 else:
                     subjid = temp[0]
-                # when per-subject mode is in use, skip rows for other subjects
+                # when per-subject mode is in use, skip rows for other subjects.
+                # Tolerate the common (older-BIDS / ABIDE) case where
+                # participants.tsv ids are not zero-padded but the subject
+                # directories are (e.g. "50792" vs "sub-0050792") by comparing
+                # with leading zeros stripped.  The imaging path
+                # (addimagingsessions) already reconciles the two via
+                # subject_id.lstrip("0").
                 if subject_filter is not None and subjid != subject_filter:
-                    continue
+                    if subjid.lstrip("0") == subject_filter.lstrip("0"):
+                        logging.warning(
+                            "participants.tsv participant_id '%s' does not match "
+                            "BIDS subject directory 'sub-%s' exactly; matched "
+                            "after normalizing leading zeros. For BIDS "
+                            "compliance, participant_id should be 'sub-%s'.",
+                            row["participant_id"],
+                            subject_filter,
+                            subject_filter,
+                        )
+                    else:
+                        continue
                 logging.info(subjid)
                 # add session and keep track if it for later using subjid
                 session[subjid] = Session(project)
@@ -1464,15 +1481,23 @@ def bidsmri2project(
             )
 
             for row in pheno_data:
-                subjid = row["participant_id"].split("-")
-                # when per-subject mode is in use, skip phenotype rows for other subjects
-                if subject_filter is not None and subjid[1] != subject_filter:
+                # parse subject id tolerantly: participant_id may be "sub-XXXX"
+                # or a bare "XXXX" (older BIDS / non-compliant datasets)
+                temp = row["participant_id"].split("-")
+                sid = temp[1] if len(temp) > 1 else temp[0]
+                # when per-subject mode is in use, skip phenotype rows for other
+                # subjects (compare with leading zeros stripped, matching the
+                # participants.tsv handling above)
+                if (
+                    subject_filter is not None
+                    and sid.lstrip("0") != subject_filter.lstrip("0")
+                ):
                     continue
                 # add acquisition object
-                acq = AssessmentAcquisition(session=session[subjid[1]])
+                acq = AssessmentAcquisition(session=session[sid])
                 # add qualified association with person
                 acq.add_qualified_association(
-                    person=participant[subjid[1]]["person"],
+                    person=participant[sid]["person"],
                     role=Constants.NIDM_PARTICIPANT,
                 )
                 # add acquisition entity and associate it with the acquisition activity

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import re
 import sys
 import click
-from rdflib import Graph, Namespace
+from rdflib import Graph, Literal, Namespace
 from nidm.experiment.tools.click_base import cli
 
 # ---------------------------------------------------------------------------
@@ -25,6 +25,11 @@ NIDM = Namespace("http://purl.org/nidash/nidm#")
 RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
 DCT = Namespace("http://purl.org/dc/terms/")
 RDF_NS = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+# NIDM encodes a DataElement's value levels (coded value -> human label) as
+# reproschema:choices -> bnode(reproschema:value, rdfs:label).  Namespace is
+# http://schema.repronim.org/ (NOT the ".../reproschema#" form models tend to
+# guess).
+REPROSCHEMA = Namespace("http://schema.repronim.org/")
 
 _SCHEMA_PATH = Path(__file__).resolve().parent.parent / "schema" / "nidm_schema.json"
 
@@ -94,6 +99,22 @@ def _extract_data_elements(nidm_files):
                 entry["structure"] = str(o)
             elif plocal == "measure" and "measure" not in entry:
                 entry["measure"] = str(o)
+
+        # Value levels (coded value -> human label), when defined in the data.
+        # NIDM stores these as reproschema:choices -> bnode(reproschema:value,
+        # rdfs:label).  Only captured when BOTH a value and a label are present;
+        # this is the ONLY thing that licenses queryai to translate coded values
+        # (e.g. sex "1" -> "Male").  Absent here => no mapping is possible.
+        levels = {}
+        for choice in g.objects(de, REPROSCHEMA["choices"]):
+            if isinstance(choice, Literal):
+                continue  # bare enumerated value, no value->label pair
+            val = next(g.objects(choice, REPROSCHEMA["value"]), None)
+            lab = next(g.objects(choice, RDFS["label"]), None)
+            if val is not None and lab is not None:
+                levels[str(val)] = str(lab)
+        if levels:
+            entry["levels"] = levels
 
         data_elements.append(entry)
 
@@ -497,6 +518,16 @@ def _build_sparql_prompt(resolved_vars, prefixes, projects):
             var_block += f"    Laterality: {v['laterality']}\n"
         if v.get("unit"):
             var_block += f"    Unit: {v['unit']}\n"
+        if v.get("levels"):
+            var_block += (
+                f"    Value levels (coded -> label, the ONLY permitted "
+                f"mapping for this variable): {v['levels']}\n"
+            )
+        else:
+            var_block += (
+                "    Value levels: NONE in the data — do NOT translate this "
+                "variable's coded values; return them raw.\n"
+            )
 
     return f"""\
 You are a SPARQL query generator for NIDM (Neuroimaging Data Model) RDF graphs.
@@ -555,6 +586,22 @@ You MUST use the exact URIs listed below — do NOT substitute or invent URIs.
    Do NOT invent, guess, or modify any URI. If a variable has no resolved
    URI (role is identifier/aggregate/software), follow the schema patterns
    instead.  NEVER use placeholders like <YOUR_URI_HERE>.
+
+8. **NEVER invent value mappings — this is critical.**
+   A coded value (e.g. sex "1"/"2", diagnosis "1"/"2") may be translated to a
+   human-readable label ONLY when that variable lists "Value levels" in
+   RESOLVED VARIABLES above.
+   - If levels ARE listed: map using EXACTLY those coded->label pairs (a BIND
+     or inline VALUES table), and nothing else.
+   - If a variable's "Value levels" is NONE: return its RAW value unchanged.
+     Do NOT translate it from outside/domain knowledge (dataset conventions,
+     ABIDE coding, "1 usually means male", etc.), and do NOT emit a no-op
+     `reproschema:choices` (or similar) triple to disguise a hardcoded guess.
+   It is far better to return the raw coded value than a fabricated label.
+   When the user asked for a mapping you cannot perform (no levels in the
+   data), add a top-level SPARQL comment line for each such variable:
+   `# NOTE: no value-level definitions for <var> in the data; returning raw values`
+   and select the raw value.
 
 ## Available Prefixes
 ```sparql

--- a/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
+++ b/tests/experiment/tools/test_bidsmri2nidm_per_subject.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import subprocess
 import sys
 import pytest
-from rdflib import RDF, Graph
+from rdflib import RDF, Graph, Literal
 from rdflib.namespace import Namespace
 
 NIDM = Namespace("http://purl.org/nidash/nidm#")
@@ -227,3 +227,65 @@ def test_relative_output_path_is_resolved_and_created(
     g = Graph()
     g.parse(produced, format="turtle")
     assert len(g) > 0
+
+
+def _make_bids_zero_stripped(root: Path, subjects: list[str]) -> None:
+    """BIDS dataset where subject directories are zero-padded (``sub-00xx``)
+    but participants.tsv ``participant_id`` values are NOT (the ABIDE /
+    older-BIDS quirk).  Includes an ``age`` column so there is a demographic
+    value to attach."""
+    (root / "dataset_description.json").write_text(
+        json.dumps({"Name": "zero-strip test", "BIDSVersion": "1.8.0"})
+    )
+    header = "participant_id\tage\n"
+    rows = "".join(f"{s.lstrip('0')}\t{20 + i}\n" for i, s in enumerate(subjects))
+    (root / "participants.tsv").write_text(header + rows)
+    # Pre-written sidecar so map_variables_to_terms annotates `age` without
+    # prompting interactively (no network / no stdin needed).
+    (root / "participants.json").write_text(
+        json.dumps(
+            {
+                "age": {
+                    "description": "Age in years",
+                    "source_variable": "age",
+                    "associatedWith": "NIDM",
+                    "valueType": "http://www.w3.org/2001/XMLSchema#integer",
+                }
+            }
+        )
+    )
+    for s in subjects:
+        anat = root / f"sub-{s}" / "anat"
+        anat.mkdir(parents=True)
+        (anat / f"sub-{s}_T1w.nii.gz").write_bytes(b"")
+
+
+def test_per_subject_demographics_with_zero_stripped_participant_ids(
+    tmp_path: Path,
+) -> None:
+    """Regression: when participants.tsv ids are zero-stripped (``50772``) but
+    the subject directories are zero-padded (``sub-0050772``), --per_subject
+    must still write the demographics.  Previously the per-subject filter
+    skipped the row on a strict string compare, yielding CDE definitions but no
+    values."""
+    bids = tmp_path / "bids"
+    bids.mkdir()
+    _make_bids_zero_stripped(bids, ["0050772", "0050773"])
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+
+    result = _run_bidsmri2nidm(
+        ["-d", str(bids), "--per_subject", "-o", str(out_dir), "--no_concepts"]
+    )
+    assert result.returncode == 0, f"bidsmri2nidm failed:\n{result.stderr}"
+
+    ttl = out_dir / "sub-0050772" / "nidm.ttl"
+    assert ttl.is_file()
+    g = Graph()
+    g.parse(ttl, format="turtle")
+    # the age value (20 for the first subject) must be present; before the fix
+    # the participants row was skipped so no demographic value was written.
+    literals = {str(o) for (_s, _p, o) in g if isinstance(o, Literal)}
+    assert (
+        "20" in literals
+    ), "demographic age value not written for zero-stripped participant_id"

--- a/tests/experiment/tools/test_nidm_queryai.py
+++ b/tests/experiment/tools/test_nidm_queryai.py
@@ -1,0 +1,38 @@
+"""Tests for nidm_queryai helpers that don't require an AI/API call."""
+
+from __future__ import annotations
+from pathlib import Path
+from nidm.experiment.tools.nidm_queryai import _extract_data_elements
+
+
+def test_extract_data_elements_captures_value_levels(tmp_path: Path) -> None:
+    """A DataElement whose value levels are defined in the data (via
+    reproschema:choices -> value/label) is captured as a coded->label dict;
+    a DataElement with no level definitions has no 'levels' key.  This is what
+    licenses queryai to translate coded values (and refuse when absent)."""
+    ttl = """
+@prefix niiri: <http://iri.nidash.org/> .
+@prefix nidm: <http://purl.org/nidash/nidm#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix reproschema: <http://schema.repronim.org/> .
+
+niiri:SEX_withlevels a nidm:PersonalDataElement ;
+    rdfs:label "SEX" ;
+    reproschema:choices [ reproschema:value "1" ; rdfs:label "Male" ] ,
+                        [ reproschema:value "2" ; rdfs:label "Female" ] .
+
+niiri:DX_nolevels a nidm:PersonalDataElement ;
+    rdfs:label "diagnostic group" .
+"""
+    cde = tmp_path / "cde.ttl"
+    cde.write_text(ttl, encoding="utf-8")
+
+    data_elements, _g = _extract_data_elements([str(cde)])
+    by_uri = {d["uri"]: d for d in data_elements}
+
+    sex = by_uri["http://iri.nidash.org/SEX_withlevels"]
+    dx = by_uri["http://iri.nidash.org/DX_nolevels"]
+
+    assert sex.get("levels") == {"1": "Male", "2": "Female"}
+    # No level definitions -> no 'levels' key -> queryai must not fabricate a mapping
+    assert "levels" not in dx


### PR DESCRIPTION
## Summary

Fixes silent loss of all participant demographics in `bidsmri2nidm --per_subject`
when a dataset's `participants.tsv` `participant_id` values are not zero-padded
but the subject directories are (e.g. ABIDE: `50772` vs `sub-0050772`).

## Problem

In `--per_subject` mode the participants.tsv row was selected by comparing the
participants-derived id to the BIDS subject-directory id with **strict string
equality** (`subjid != subject_filter`). For datasets where `participant_id` is
zero-stripped (`50772`) while the directory is padded (`sub-0050772`), every row
was skipped. The data-element *definitions* are emitted before that loop, so the
output contained the participant CDE definitions but **no demographic values and
no AssessmentObject** — demographics were silently dropped.

(The imaging path, `addimagingsessions`, already reconciles this mismatch via
`subject_id.lstrip("0")`; the bug was only that the per-subject filter discarded
the row before that reconciliation could run.)

This is consistent with the BIDS spec history: older BIDS only required
`participant_id` to "consist of `sub-<label>`", with no constraint that it match
the subject directories; the directory-superset requirement was tightened in
later versions. pybids parses uniformly regardless of `BIDSVersion`, so such
datasets flow through without complaint.

## Changes

- **`bidsmri2nidm.py` participants loop:** compare the per-subject filter with
  leading zeros stripped, so `50772` matches `sub-0050772` and the row is
  processed. The existing `addimagingsessions` reconciliation then attaches the
  imaging acquisitions to the same Person, so demographics + imaging share one
  node. Emits a `logging.warning` when a row matched only after normalization,
  flagging the non-compliant `participant_id` (no silent fixes).
- **`phenotype/*.tsv` loop:** made tolerant of bare `participant_id`s (it used
  `subjid[1]`, which raised `IndexError` on a bare id) and given the same
  normalized, leading-zero-tolerant match.
- **Regression test:** `--per_subject` over zero-stripped `participant_id`s with
  padded subject directories now asserts the demographic value is written.

## Testing

`pytest tests/experiment/tools/test_bidsmri2nidm_per_subject.py -q` — 7 passed.

## Notes

The normalization only ever relaxes the id comparison: on spec-compliant data
it's a no-op, and it never needs to change as BIDS tightens. Structural BIDS
parsing remains delegated to pybids.