### PR TITLE
queryai: deterministic person-anchored SPARQL builder for retrieval queries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -608,11 +608,17 @@ offline use.  It uses a two-phase approach:
    ``nidm:sourceVariable``.  If multiple DataElements match, you are
    prompted to select the correct one(s).
 
-2. **Phase 2 — SPARQL Generation:** The resolved URIs, together with the
-   NIDM graph structure from the bundled ``nidm_schema.json``, are sent to
-   the LLM which generates a SPARQL query.  The query is executed locally
+2. **Phase 2 — SPARQL Generation:** For a plain "retrieve these variables"
+   question the tool builds the SPARQL **itself, in code** (no LLM) from the
+   resolved URIs — a person-anchored, zero-padding-tolerant query that joins
+   every variable back to the same subject.  This is fully reproducible
+   regardless of which model ran Phase 1, and avoids the cartesian products
+   and cross-file subject-id mismatches that an LLM-authored join is prone to.
+   For analytical questions (counts, averages, group-by, filtering) the LLM
+   generates the query instead, guided by the NIDM graph structure from the
+   bundled ``nidm_schema.json``.  Either way the query is executed locally
    against your NIDM files via rdflib — **no subject data leaves your
-   machine**.
+   machine**.  See *Query modes* below; ``-s`` shows the query before it runs.
 
 .. code:: bash
 
@@ -627,6 +633,13 @@ offline use.  It uses a two-phase approach:
      -o, --output_file PATH      Optional output file for results (TSV format)
      -s, --show_query            Show the generated SPARQL query before
                                  executing it
+     -m, --mode [auto|deterministic|llm]
+                                 How Phase 2 builds the SPARQL.  'deterministic'
+                                 assembles a person-anchored, zero-padding-
+                                 tolerant query in code from the resolved URIs;
+                                 'llm' always asks the AI; 'auto' (default) uses
+                                 the deterministic builder for plain retrieval
+                                 questions and the AI for analytical ones.
      --help                      Show this message and exit.
 
 **Prerequisites — choose an LLM provider.**  ``queryai`` can use a cloud API
@@ -649,24 +662,43 @@ below is present.
    export OPENAI_API_KEY=sk-...
 
 *Optional local server (no API key, runs offline).*  ``queryai`` can talk to any
-local **OpenAI-compatible** LLM server — for example the ``llama-server``
-shipped with `llama.cpp <https://github.com/ggml-org/llama.cpp>`_, or
-`Ollama <https://ollama.com>`_.  Start the server, then point ``queryai`` at it:
+local **OpenAI-compatible** LLM server, so it can run with no cloud account and
+with nothing leaving your machine.  Two common backends are `llama.cpp
+<https://github.com/ggml-org/llama.cpp>`_ (its ``llama-server``) and `Ollama
+<https://ollama.com>`_.
+
+With **llama.cpp**, install it and start ``llama-server`` with an instruct model.
+``-hf`` downloads a GGUF from HuggingFace and caches it on first run, ``-ngl 99``
+offloads layers to the GPU (Apple Silicon / CUDA), and ``-c`` sets the context
+size (use a generous value — the Phase 2 prompt includes the NIDM schema):
 
 .. code:: bash
 
-   # llama.cpp: serves an OpenAI-compatible API on :8080 (use a generous context)
-   llama-server -m /path/to/model.gguf -c 8192
+   brew install llama.cpp                                          # macOS; see llama.cpp for other platforms
+
+   llama-server -hf bartowski/Qwen2.5-7B-Instruct-GGUF:Q4_K_M -c 16384 -ngl 99
+
+This serves an OpenAI-compatible API on ``http://localhost:8080``.  Then point
+``queryai`` at it and run as usual:
+
+.. code:: bash
 
    export PYNIDM_AI_PROVIDER=llama
-   # defaults below match llama.cpp; override for Ollama, etc.
-   export PYNIDM_LLAMA_URL=http://localhost:8080/v1   # Ollama: http://localhost:11434/v1
-   export PYNIDM_LLAMA_MODEL=local-model              # Ollama: the model tag, e.g. llama3
+   export PYNIDM_LLAMA_URL=http://localhost:8080/v1
+   export PYNIDM_LLAMA_MODEL=local-model     # llama.cpp ignores this; any value is fine
 
-With a local server, **nothing leaves your machine** — not the question, the
-schema, or your data.  Note that local models are typically less reliable than
-Claude/GPT at producing valid SPARQL; prefer a capable instruct model with a
-large context window, and inspect the generated query with ``-s``.
+   pynidm queryai -nl data/nidm.ttl -q "How many subjects are there?" -s
+
+To use **Ollama** instead, run ``ollama serve`` and ``ollama pull llama3``, then
+set ``PYNIDM_LLAMA_URL=http://localhost:11434/v1`` and
+``PYNIDM_LLAMA_MODEL=llama3`` (the model tag).
+
+With a local server **nothing leaves your machine** — not the question, the
+schema, or your data.  Model choice matters: a 7B model handles simple queries,
+but complex multi-variable queries are far more reliable with a 14B+ instruct
+model (e.g. ``Qwen2.5-14B-Instruct-GGUF:Q4_K_M``) if you have the memory.  Local
+models are generally less reliable than Claude/GPT at producing valid SPARQL, so
+always inspect the generated query with ``-s``.
 
 A cloud provider + key may instead be stored in a config file at
 ``~/.pynidm/config.json``::
@@ -690,6 +722,27 @@ A cloud provider + key may instead be stored in a config file at
 .. code:: bash
 
    pynidm queryai -nl data/nidm.ttl
+
+**Query modes (-m).**  By default (``-m auto``) a plain "retrieve / list /
+show these variables" question is answered by the **deterministic builder**:
+the SPARQL is assembled in code from the resolved DataElement URIs, so the
+result is identical no matter which model (cloud or local) ran Phase 1, and is
+immune to the cartesian-product and cross-file subject-id problems an
+LLM-written join can introduce.  Each variable is joined back to the same
+subject through the NIDM provenance backbone, and subject ids are matched after
+stripping leading zeros so a demographics file (``50772``) lines up with a
+FreeSurfer/FSL derivative file (``0050772``).  Coded values are translated to
+labels **only** when the DataElement defines value levels
+(``reproschema:choices``); otherwise the raw value is returned and a note is
+printed — queryai never fabricates a mapping.  Analytical questions (counts,
+averages, group-by, filtering) are routed to the LLM.  Force a path with
+``-m deterministic`` or ``-m llm``.
+
+.. code:: bash
+
+   # deterministic, reproducible, runs even with a small local model
+   pynidm queryai -nl demographics.ttl,freesurfer_cde.ttl \
+     -q "Retrieve age, sex, diagnosis, and left and right hippocampus volume" -s
 
 A demo script that downloads sample NIDM data and runs several example
 queries is available at

--- a/README.rst
+++ b/README.rst
@@ -596,8 +596,9 @@ Details on the REST API URI format and usage can be found below.
 queryai — AI-Assisted Natural Language Query
 --------------------------------------------
 This tool translates natural-language questions about your NIDM data into
-SPARQL queries using an LLM (Anthropic Claude or OpenAI GPT).  It uses a
-two-phase approach:
+SPARQL queries using an LLM — either a cloud API (Anthropic Claude or OpenAI
+GPT) or an optional local LLM server (e.g. llama.cpp or Ollama) for fully
+offline use.  It uses a two-phase approach:
 
 1. **Phase 1 — Concept Resolution:** The AI extracts variable concepts
    (e.g. "age", "left hippocampus volume") from your question.  The tool
@@ -627,14 +628,47 @@ two-phase approach:
                                  executing it
      --help                      Show this message and exit.
 
-**Prerequisites** — an API key for either Anthropic or OpenAI:
+**Prerequisites — choose an LLM provider.**  ``queryai`` can use a cloud API
+(Anthropic or OpenAI) or an optional local LLM server, so it can run fully
+offline with no API key.  The provider is selected by the ``PYNIDM_AI_PROVIDER``
+environment variable (``anthropic`` | ``openai`` | ``llama``, case-insensitive);
+if it is unset the provider is auto-detected from whichever of the variables
+below is present.
+
+*Anthropic (Claude):*
 
 .. code:: bash
 
-   export ANTHROPIC_API_KEY=sk-ant-...   # or
+   export ANTHROPIC_API_KEY=sk-ant-...
+
+*OpenAI (GPT):*
+
+.. code:: bash
+
    export OPENAI_API_KEY=sk-...
 
-Or create a config file at ``~/.pynidm/config.json``::
+*Optional local server (no API key, runs offline).*  ``queryai`` can talk to any
+local **OpenAI-compatible** LLM server — for example the ``llama-server``
+shipped with `llama.cpp <https://github.com/ggml-org/llama.cpp>`_, or
+`Ollama <https://ollama.com>`_.  Start the server, then point ``queryai`` at it:
+
+.. code:: bash
+
+   # llama.cpp: serves an OpenAI-compatible API on :8080 (use a generous context)
+   llama-server -m /path/to/model.gguf -c 8192
+
+   export PYNIDM_AI_PROVIDER=llama
+   # defaults below match llama.cpp; override for Ollama, etc.
+   export PYNIDM_LLAMA_URL=http://localhost:8080/v1   # Ollama: http://localhost:11434/v1
+   export PYNIDM_LLAMA_MODEL=local-model              # Ollama: the model tag, e.g. llama3
+
+With a local server, **nothing leaves your machine** — not the question, the
+schema, or your data.  Note that local models are typically less reliable than
+Claude/GPT at producing valid SPARQL; prefer a capable instruct model with a
+large context window, and inspect the generated query with ``-s``.
+
+A cloud provider + key may instead be stored in a config file at
+``~/.pynidm/config.json``::
 
    {"provider": "anthropic", "api_key": "sk-ant-..."}
 

--- a/README.rst
+++ b/README.rst
@@ -365,14 +365,14 @@ register for an account, then click on "MyAccount" and "API Keys" to add a new
 API key for your account.
 
 
-.. code:: bash
+.. code:: text
 
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
 
-   # Write one NIDM file per subject (sub-<id>_nidm.ttl) into the BIDS directory:
+   # Write one NIDM file per subject as BIDS_ROOT/sub-<id>/nidm.ttl:
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject
 
-   # Or direct the per-subject files to a different output directory:
+   # Or direct the per-subject files under a different base output directory:
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject -o [OUTPUT DIRECTORY]
 
    usage: bidsmri2nidm [-h] -d DIRECTORY [-jsonld] [-bidsignore] [-no_concepts]
@@ -396,15 +396,16 @@ API key for your account.
                         If flag set, tool will no do concept mapping
      -log LOGFILE, --log LOGFILE
                         Full path to directory to save log file. Log file name is bidsmri2nidm_[basename(args.directory)].log
-     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here.
-                           In ``--per_subject`` mode this argument is interpreted as an output **directory** (created if missing)
-                           into which one ``sub-<id>_nidm.ttl`` file is written per subject.
+     -o OUTPUTFILE         Output turtle file path; defaults to nidm.ttl in the BIDS directory.  Accepts an absolute or
+                           relative path (relative paths resolve against the current working directory; missing parent
+                           directories are created).  In --per_subject mode this is the base output directory, beneath
+                           which one sub-<id>/nidm.ttl is written per subject.
      -per_subject, --per_subject
-                        If flag set, a separate NIDM turtle file will be written for each subject in the BIDS directory,
-                        named ``sub-<id>_nidm.ttl``.  By default these are placed in the BIDS directory; use ``-o`` to
-                        specify a different output directory.  When combined with ``-bidsignore``, each per-subject file
-                        is appended to the BIDS dataset's ``.bidsignore`` file (only when the output directory lies
-                        inside the BIDS tree).
+                        If flag set, a separate NIDM turtle file named nidm.ttl is written into each subject's BIDS
+                        directory, i.e. BIDS_ROOT/sub-<id>/nidm.ttl.  By default these go under the BIDS directory; use
+                        -o to specify a different base output directory.  When combined with -bidsignore, each
+                        sub-<id>/nidm.ttl is added to the BIDS dataset's .bidsignore file (when the output lies inside
+                        the BIDS tree).
 
    map variables to terms arguments:
      -json_map JSON_MAP, --json_map JSON_MAP

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -592,8 +592,9 @@ option is required (the group is mutually exclusive).
 QueryAI — AI-Assisted Natural Language Query
 ---------------------------------------------
 This tool translates natural-language questions about your NIDM data into
-SPARQL queries using an LLM (Anthropic Claude or OpenAI GPT).  It uses a
-two-phase approach:
+SPARQL queries using an LLM — either a cloud API (Anthropic Claude or OpenAI
+GPT) or an optional local LLM server (e.g. llama.cpp or Ollama) for fully
+offline use.  It uses a two-phase approach:
 
 1. **Phase 1 — Concept Resolution:** The AI extracts variable concepts
    (e.g. "age", "left hippocampus volume") from your question.  The tool
@@ -623,16 +624,48 @@ two-phase approach:
                                  executing it
      --help                      Show this message and exit.
 
-**Prerequisites:**
+**Prerequisites — choose an LLM provider.**
 
-An API key for either Anthropic or OpenAI is required.  Set one of:
+``queryai`` can use a cloud API (Anthropic or OpenAI) or an optional local LLM
+server, so it can run fully offline with no API key.  The provider is selected
+by the ``PYNIDM_AI_PROVIDER`` environment variable
+(``anthropic`` | ``openai`` | ``llama``, case-insensitive); if it is unset the
+provider is auto-detected from whichever of the variables below is present.
+
+*Anthropic (Claude):*
 
 .. code:: bash
 
    export ANTHROPIC_API_KEY=sk-ant-...
+
+*OpenAI (GPT):*
+
+.. code:: bash
+
    export OPENAI_API_KEY=sk-...
 
-Or create a config file at ``~/.pynidm/config.json``:
+*Optional local server (no API key, runs offline).*  ``queryai`` can talk to any
+local **OpenAI-compatible** LLM server — for example the ``llama-server``
+shipped with `llama.cpp <https://github.com/ggml-org/llama.cpp>`_, or
+`Ollama <https://ollama.com>`_.  Start the server, then point ``queryai`` at it:
+
+.. code:: bash
+
+   # llama.cpp: serves an OpenAI-compatible API on :8080 (use a generous context)
+   llama-server -m /path/to/model.gguf -c 8192
+
+   export PYNIDM_AI_PROVIDER=llama
+   # defaults below match llama.cpp; override for Ollama, etc.
+   export PYNIDM_LLAMA_URL=http://localhost:8080/v1   # Ollama: http://localhost:11434/v1
+   export PYNIDM_LLAMA_MODEL=local-model              # Ollama: the model tag, e.g. llama3
+
+With a local server, **nothing leaves your machine** — not the question, the
+schema, or your data.  Local models are typically less reliable than Claude/GPT
+at producing valid SPARQL; prefer a capable instruct model with a large context
+window, and inspect the generated query with ``-s``.
+
+A cloud provider + key may instead be stored in a config file at
+``~/.pynidm/config.json``:
 
 .. code:: json
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -604,11 +604,17 @@ offline use.  It uses a two-phase approach:
    ``nidm:sourceVariable`` properties.  If multiple DataElements match,
    you are prompted to select the correct one(s).
 
-2. **Phase 2 — SPARQL Generation:** The resolved URIs, along with the
-   NIDM graph structure (loaded from the bundled ``nidm_schema.json``),
-   are sent to the LLM which generates a SPARQL query.  The query is
-   executed locally against your NIDM files via rdflib — **no subject
-   data leaves your machine**.
+2. **Phase 2 — SPARQL Generation:** For a plain "retrieve these variables"
+   question the tool builds the SPARQL **itself, in code** (no LLM) from the
+   resolved URIs — a person-anchored, zero-padding-tolerant query that joins
+   every variable back to the same subject.  This is fully reproducible
+   regardless of which model ran Phase 1, and avoids the cartesian products
+   and cross-file subject-id mismatches that an LLM-authored join is prone to.
+   For analytical questions (counts, averages, group-by, filtering) the LLM
+   generates the query instead, using the NIDM graph structure loaded from the
+   bundled ``nidm_schema.json``.  Either way the query is executed locally
+   against your NIDM files via rdflib — **no subject data leaves your
+   machine**.  See *Query modes* below.
 
 .. code:: bash
 
@@ -623,6 +629,13 @@ offline use.  It uses a two-phase approach:
      -o, --output_file PATH      Optional output file for results (TSV format)
      -s, --show_query            Show the generated SPARQL query before
                                  executing it
+     -m, --mode [auto|deterministic|llm]
+                                 How Phase 2 builds the SPARQL.  'deterministic'
+                                 assembles a person-anchored, zero-padding-
+                                 tolerant query in code from the resolved URIs;
+                                 'llm' always asks the AI; 'auto' (default) uses
+                                 the deterministic builder for plain retrieval
+                                 questions and the AI for analytical ones.
      --help                      Show this message and exit.
 
 **Prerequisites — choose an LLM provider.**
@@ -646,24 +659,43 @@ provider is auto-detected from whichever of the variables below is present.
    export OPENAI_API_KEY=sk-...
 
 *Optional local server (no API key, runs offline).*  ``queryai`` can talk to any
-local **OpenAI-compatible** LLM server — for example the ``llama-server``
-shipped with `llama.cpp <https://github.com/ggml-org/llama.cpp>`_, or
-`Ollama <https://ollama.com>`_.  Start the server, then point ``queryai`` at it:
+local **OpenAI-compatible** LLM server, so it can run with no cloud account and
+with nothing leaving your machine.  Two common backends are `llama.cpp
+<https://github.com/ggml-org/llama.cpp>`_ (its ``llama-server``) and `Ollama
+<https://ollama.com>`_.
+
+With **llama.cpp**, install it and start ``llama-server`` with an instruct model.
+``-hf`` downloads a GGUF from HuggingFace and caches it on first run, ``-ngl 99``
+offloads layers to the GPU (Apple Silicon / CUDA), and ``-c`` sets the context
+size (use a generous value — the Phase 2 prompt includes the NIDM schema):
 
 .. code:: bash
 
-   # llama.cpp: serves an OpenAI-compatible API on :8080 (use a generous context)
-   llama-server -m /path/to/model.gguf -c 8192
+   brew install llama.cpp                                          # macOS; see llama.cpp for other platforms
+
+   llama-server -hf bartowski/Qwen2.5-7B-Instruct-GGUF:Q4_K_M -c 16384 -ngl 99
+
+This serves an OpenAI-compatible API on ``http://localhost:8080``.  Then point
+``queryai`` at it and run as usual:
+
+.. code:: bash
 
    export PYNIDM_AI_PROVIDER=llama
-   # defaults below match llama.cpp; override for Ollama, etc.
-   export PYNIDM_LLAMA_URL=http://localhost:8080/v1   # Ollama: http://localhost:11434/v1
-   export PYNIDM_LLAMA_MODEL=local-model              # Ollama: the model tag, e.g. llama3
+   export PYNIDM_LLAMA_URL=http://localhost:8080/v1
+   export PYNIDM_LLAMA_MODEL=local-model     # llama.cpp ignores this; any value is fine
 
-With a local server, **nothing leaves your machine** — not the question, the
-schema, or your data.  Local models are typically less reliable than Claude/GPT
-at producing valid SPARQL; prefer a capable instruct model with a large context
-window, and inspect the generated query with ``-s``.
+   pynidm queryai -nl data/nidm.ttl -q "How many subjects are there?" -s
+
+To use **Ollama** instead, run ``ollama serve`` and ``ollama pull llama3``, then
+set ``PYNIDM_LLAMA_URL=http://localhost:11434/v1`` and
+``PYNIDM_LLAMA_MODEL=llama3`` (the model tag).
+
+With a local server **nothing leaves your machine** — not the question, the
+schema, or your data.  Model choice matters: a 7B model handles simple queries,
+but complex multi-variable queries are far more reliable with a 14B+ instruct
+model (e.g. ``Qwen2.5-14B-Instruct-GGUF:Q4_K_M``) if you have the memory.  Local
+models are generally less reliable than Claude/GPT at producing valid SPARQL, so
+always inspect the generated query with ``-s``.
 
 A cloud provider + key may instead be stored in a config file at
 ``~/.pynidm/config.json``:
@@ -716,6 +748,29 @@ from both FreeSurfer and ANTs), you will be prompted to select::
 
    Question: How many subjects have a diagnosis of autism?
    ...
+
+**Query modes (-m).**
+
+By default (``-m auto``) a plain "retrieve / list / show these variables"
+question is answered by the **deterministic builder**: the SPARQL is assembled
+in code from the resolved DataElement URIs, so the result is identical no matter
+which model (cloud or local) ran Phase 1, and is immune to the cartesian-product
+and cross-file subject-id problems an LLM-written join can introduce.  Each
+variable is joined back to the same subject through the NIDM provenance backbone
+(``entity → prov:wasGeneratedBy → activity → prov:qualifiedAssociation →
+prov:agent → Person``), and subject ids are matched after stripping leading
+zeros so a demographics file (``50772``) lines up with a FreeSurfer/FSL
+derivative file (``0050772``).  Coded values are translated to labels **only**
+when the DataElement defines value levels (``reproschema:choices``); otherwise
+the raw value is returned and a note is printed — queryai never fabricates a
+mapping.  Analytical questions (counts, averages, group-by, filtering) are
+routed to the LLM.  Use ``-m deterministic`` or ``-m llm`` to force a path.
+
+.. code:: bash
+
+   # deterministic, reproducible, runs even with a small local model
+   pynidm queryai -nl demographics.ttl,freesurfer_cde.ttl \
+     -q "Retrieve age, sex, diagnosis, and left and right hippocampus volume" -s
 
 **Demo Script:**
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -363,14 +363,14 @@ register for an account, then click on "MyAccount" and "API Keys" to add a new
 API key for your account.
 
 
-.. code:: bash
+.. code:: text
 
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] -bidsignore
 
-   # Write one NIDM file per subject (sub-<id>_nidm.ttl) into the BIDS directory:
+   # Write one NIDM file per subject as BIDS_ROOT/sub-<id>/nidm.ttl:
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject
 
-   # Or direct the per-subject files to a different output directory:
+   # Or direct the per-subject files under a different base output directory:
    $ bidsmri2nidm -d [ROOT BIDS DIRECT] --per_subject -o [OUTPUT DIRECTORY]
 
    usage: bidsmri2nidm [-h] -d DIRECTORY [-jsonld] [-bidsignore] [-no_concepts]
@@ -394,15 +394,16 @@ API key for your account.
                         If flag set, tool will no do concept mapping
      -log LOGFILE, --log LOGFILE
                         Full path to directory to save log file. Log file name is bidsmri2nidm_[basename(args.directory)].log
-     -o OUTPUTFILE         Outputs turtle file called nidm.ttl in BIDS directory by default..or whatever path/filename is set here.
-                           In ``--per_subject`` mode this argument is interpreted as an output **directory** (created if missing)
-                           into which one ``sub-<id>_nidm.ttl`` file is written per subject.
+     -o OUTPUTFILE         Output turtle file path; defaults to nidm.ttl in the BIDS directory.  Accepts an absolute or
+                           relative path (relative paths resolve against the current working directory; missing parent
+                           directories are created).  In --per_subject mode this is the base output directory, beneath
+                           which one sub-<id>/nidm.ttl is written per subject.
      -per_subject, --per_subject
-                        If flag set, a separate NIDM turtle file will be written for each subject in the BIDS directory,
-                        named ``sub-<id>_nidm.ttl``.  By default these are placed in the BIDS directory; use ``-o`` to
-                        specify a different output directory.  When combined with ``-bidsignore``, each per-subject file
-                        is appended to the BIDS dataset's ``.bidsignore`` file (only when the output directory lies
-                        inside the BIDS tree).
+                        If flag set, a separate NIDM turtle file named nidm.ttl is written into each subject's BIDS
+                        directory, i.e. BIDS_ROOT/sub-<id>/nidm.ttl.  By default these go under the BIDS directory; use
+                        -o to specify a different base output directory.  When combined with -bidsignore, each
+                        sub-<id>/nidm.ttl is added to the BIDS dataset's .bidsignore file (when the output lies inside
+                        the BIDS tree).
 
    map variables to terms arguments:
      -json_map JSON_MAP, --json_map JSON_MAP

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -26,6 +26,12 @@ NIDM = Namespace("http://purl.org/nidash/nidm#")
 RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
 DCT = Namespace("http://purl.org/dc/terms/")
 RDF_NS = Namespace("http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+PROV = Namespace("http://www.w3.org/ns/prov#")
+# Subjects are identified by ndar:src_subject_id.  The SAME human can appear
+# under different Person nodes (one per source file) and with differently
+# zero-padded ids ("50772" in demographics vs "0050772" in a FreeSurfer/FSL
+# derivative); the deterministic builder normalizes by stripping leading zeros.
+NDAR = Namespace("https://ndar.nih.gov/api/datadictionary/v2/dataelement/")
 # NIDM encodes a DataElement's value levels (coded value -> human label) as
 # reproschema:choices -> bnode(reproschema:value, rdfs:label).  Namespace is
 # http://schema.repronim.org/ (NOT the ".../reproschema#" form models tend to
@@ -546,13 +552,19 @@ You MUST use the exact URIs listed below — do NOT substitute or invent URIs.
 
 ## CRITICAL QUERY RULES
 
-1. **Anchor every query on ONE subject node — never join by the subject-id string.**
-   Bind the subject exactly once:
-   `?person ndar:src_subject_id ?subject_id .`
-   Then join EVERY value block to that shared `?person` node.  Do NOT
-   re-derive the person separately in each block, and do NOT join blocks
-   together by matching the `?subject_id` literal — that produces a near
-   cartesian product and is very slow.
+1. **Anchor EVERY value to a subject — a floating value block is the #1 bug.**
+   Each value's carrying entity MUST be tied back to a subject; an entity
+   variable that appears in a value triple but is not connected to a subject
+   ranges over ALL subjects and produces a cartesian product (e.g. one
+   subject's age paired with every subject's left x right volumes).
+   - Values from the SAME source file share one `?person`:
+     `?person ndar:src_subject_id ?subject_id .` then join each block to that
+     shared `?person` node (do not re-derive it per block).
+   - Values from DIFFERENT source files (e.g. demographics in one file,
+     FreeSurfer/FSL volumes in another) have DIFFERENT Person nodes AND the
+     `src_subject_id` may be zero-padded differently ("50772" vs "0050772").
+     Join those by the leading-zero-stripped id, NOT by the same person node:
+     `FILTER(REPLACE(STR(?id_a), "^0+", "") = REPLACE(STR(?id_b), "^0+", ""))`.
 
 2. **Locate each value via the PROV backbone + its resolved DE URI:**
    ```
@@ -604,6 +616,16 @@ You MUST use the exact URIs listed below — do NOT substitute or invent URIs.
    `# NOTE: no value-level definitions for <var> in the data; returning raw values`
    and select the raw value.
 
+9. **Valid SPARQL syntax only (not SQL).**
+   - SPARQL has NO `CASE`/`WHEN`/`END`.  For conditionals use the function
+     form `IF(condition, then_value, else_value)` (nestable), or a `VALUES`
+     table.  Example: `BIND(IF(?x = "1", "yes", "no") AS ?label)`.
+   - Never `BIND(... AS ?v)` to a variable `?v` that is already bound elsewhere
+     in the query — that is illegal.  Read the raw value into one variable
+     (e.g. `?sex_code`) and BIND the derived value into a NEW variable
+     (e.g. `?sex`).
+   - Use only SPARQL 1.1 built-ins (IF, COALESCE, BIND, FILTER, COUNT, etc.).
+
 ## Available Prefixes
 ```sparql
 {prefix_block}
@@ -618,6 +640,141 @@ You MUST use the exact URIs listed below — do NOT substitute or invent URIs.
 3. Include a PREFIX declaration for EVERY namespace prefix you use.
 4. Return ONLY the SPARQL in a ```sparql block.
 """
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 (deterministic):  build the SPARQL ourselves from resolved URIs
+# ---------------------------------------------------------------------------
+#
+# For the common "retrieve these variables per subject (optionally mapping a
+# coded value via its data-element levels)" intent, the correct query is fully
+# determined once Phase 1 has resolved the DataElement URIs.  Generating it in
+# code -- instead of asking an LLM -- makes the result identical regardless of
+# which model (Claude, GPT, a local Qwen, ...) ran Phase 1, and eliminates by
+# construction the two failure modes an LLM-authored join keeps hitting:
+#
+#   1. Cartesian products: a value block whose carrying entity is not tied back
+#      to the subject ranges over EVERY subject's entity (e.g. one subject's
+#      age paired with all N subjects' left x right hippocampus volumes).
+#   2. Cross-file no-matches: joining on the raw subject-id string silently
+#      matches nothing across files because of zero-padding ("50772"/"0050772").
+#
+# Every variable is placed in its own OPTIONAL block, anchored through the
+# universal NIDM provenance path
+#   entity -> prov:wasGeneratedBy -> activity
+#          -> prov:qualifiedAssociation -> prov:agent -> Person(src_subject_id)
+# back to the SAME leading-zero-stripped subject id.  OPTIONAL (left join) keeps
+# a subject in the output even when one variable is missing, rather than
+# dropping the row.
+
+
+def _sparql_var_name(name, used):
+    """Turn a concept name into a unique, valid SPARQL variable name."""
+    base = re.sub(r"[^0-9a-zA-Z]+", "_", str(name).strip().lower()).strip("_")
+    if not base or base[0].isdigit():
+        base = "v_" + base
+    candidate = base
+    i = 2
+    while candidate in used:
+        candidate = f"{base}_{i}"
+        i += 1
+    used.add(candidate)
+    return candidate
+
+
+def _sparql_escape(s):
+    """Escape a string for use inside a double-quoted SPARQL literal."""
+    return str(s).replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _value_map_if_chain(code_var, levels):
+    """Build a nested SPARQL IF() that maps a coded value to its label.
+
+    Falls back to the raw code for any value not present in *levels*, so an
+    unexpected code is surfaced rather than silently dropped.  *levels* is the
+    coded->label dict captured from reproschema:choices (the ONLY licensed
+    source of a mapping).
+    """
+    expr = code_var
+    for val, lab in reversed(list(levels.items())):
+        expr = f'IF({code_var} = "{_sparql_escape(val)}", "{_sparql_escape(lab)}", {expr})'
+    return expr
+
+
+def _build_deterministic_sparql(resolved_vars):
+    """Build a person-anchored, zero-pad-tolerant SELECT from resolved DE URIs.
+
+    *resolved_vars* is a list of dicts each with at least ``uri`` and ``name``;
+    an optional ``levels`` dict triggers coded->label mapping for that column.
+    Returns the SPARQL string (one row per subject, ordered by subject id).
+    """
+    used = {"subject_id", "sid_raw", "p"}
+    select_cols = ["?subject_id"]
+    blocks = []
+    for i, v in enumerate(resolved_vars):
+        col = _sparql_var_name(v.get("name", f"var_{i}"), used)
+        ent, per, sid = f"e_{i}", f"p_{i}", f"s_{i}"
+        levels = v.get("levels")
+        if levels:
+            code_var = f"?{col}_code"
+            obj = code_var
+            map_line = (
+                f"    BIND({_value_map_if_chain(code_var, levels)} AS ?{col})\n"
+            )
+        else:
+            obj = f"?{col}"
+            map_line = ""
+        blocks.append(
+            "  OPTIONAL {\n"
+            f"    ?{ent} <{v['uri']}> {obj} ;\n"
+            f"         prov:wasGeneratedBy/prov:qualifiedAssociation/prov:agent ?{per} .\n"
+            f"    ?{per} ndar:src_subject_id ?{sid} .\n"
+            f'    FILTER(REPLACE(STR(?{sid}), "^0+", "") = ?subject_id)\n'
+            f"{map_line}"
+            "  }"
+        )
+        select_cols.append(f"?{col}")
+
+    return (
+        "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        "PREFIX ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/>\n\n"
+        f"SELECT {' '.join(select_cols)}\n"
+        "WHERE {\n"
+        "  # one row per distinct (leading-zero-stripped) subject id\n"
+        "  {\n"
+        "    SELECT DISTINCT ?subject_id WHERE {\n"
+        "      ?p ndar:src_subject_id ?sid_raw .\n"
+        '      BIND(REPLACE(STR(?sid_raw), "^0+", "") AS ?subject_id)\n'
+        "    }\n"
+        "  }\n\n" + "\n".join(blocks) + "\n}\nORDER BY ?subject_id\n"
+    )
+
+
+# Words/phrases that signal an analytical question (aggregation, filtering,
+# grouping) the deterministic per-subject retrieval builder does NOT handle --
+# those are routed to the LLM Phase-2 path instead.
+_ANALYTIC_RE = re.compile(
+    r"(?i)("
+    # whole words
+    r"\b(?:count|how many|number of|mean|median|sum|total|min|minimum|max|"
+    r"maximum|ratio|stdev|std dev|standard deviation|older|younger|greater|"
+    r"less than|fewer than|more than|at least|at most|between|filter|exclude|"
+    r"having|only)\b"
+    # stems (match plurals/derivations: average(s), correlation, distribution)
+    r"|\baverag\w*|\bcorrelat\w*|\bdistribut\w*|\bproportion\w*|\bpercent\w*"
+    # grouping / per-X / inline comparisons
+    r"|group(?:ed)?\s+by|\bper\s+\w+|where\s+\w+\s*[<>=]"
+    r")"
+)
+
+
+def _looks_analytical(question):
+    """True if the question implies aggregation/filtering/grouping (-> LLM).
+
+    A plain "retrieve / list / show these variables" question returns False and
+    is handled by the deterministic builder.
+    """
+    return bool(_ANALYTIC_RE.search(question or ""))
 
 
 # ---------------------------------------------------------------------------
@@ -943,7 +1100,19 @@ def _format_results(results):
     default=False,
     help="Show the generated SPARQL query before executing it.",
 )
-def queryai(nidm_file_list, question, output_file, show_query):
+@click.option(
+    "--mode",
+    "-m",
+    type=click.Choice(["auto", "deterministic", "llm"]),
+    default="auto",
+    help="How Phase 2 builds the SPARQL.  'deterministic' assembles a "
+    "person-anchored, zero-pad-tolerant query in code from the resolved URIs "
+    "(identical output on any model, no cartesian products).  'llm' always "
+    "asks the AI.  'auto' (default) uses the deterministic builder for plain "
+    "'retrieve these variables' questions and the AI for analytical ones "
+    "(counts, averages, group-by, filtering).",
+)
+def queryai(nidm_file_list, question, output_file, show_query, mode):
     """AI-assisted natural-language query of NIDM files.
 
     Uses a two-phase approach:
@@ -1079,6 +1248,9 @@ def queryai(nidm_file_list, question, output_file, show_query):
                         "label": selected.get("label"),
                         "laterality": selected.get("laterality"),
                         "unit": selected.get("unit"),
+                        # value levels (coded -> label), if defined in the data;
+                        # the ONLY licensed source for a coded-value mapping
+                        "levels": selected.get("levels"),
                     }
                 )
 
@@ -1095,25 +1267,61 @@ def queryai(nidm_file_list, question, output_file, show_query):
                 click.echo(f"  {v['name']} -> (handled by query pattern)", err=True)
 
         # ---- Phase 2: SPARQL generation ----
-        click.echo("\nPhase 2: Generating SPARQL query...", err=True)
-
-        # Only pass resolved vars that have URIs to the SPARQL prompt
+        # Only resolved vars that have URIs can be queried as predicates.
         vars_with_uris = [v for v in resolved_vars if v.get("uri")]
 
-        system_prompt = _build_sparql_prompt(vars_with_uris, prefixes, projects)
-        ai_response = _send_to_ai(system_prompt, q)
-        sparql_query = _extract_sparql(ai_response)
-
-        if not sparql_query:
+        # Decide how to build the query.  The deterministic builder handles the
+        # common per-subject retrieval intent reproducibly; the AI handles
+        # analytical questions (counts/averages/group-by/filtering) and any
+        # case where no variable resolved to a URI.
+        use_deterministic = mode == "deterministic" or (
+            mode == "auto" and vars_with_uris and not _looks_analytical(q)
+        )
+        if mode == "deterministic" and not vars_with_uris:
             click.echo(
-                "Error: Could not extract a SPARQL query from the AI response.",
+                "  No variables resolved to URIs; cannot build a deterministic "
+                "query.  Falling back to the AI.",
                 err=True,
             )
-            click.echo(f"AI response:\n{ai_response}", err=True)
-            return
+            use_deterministic = False
+
+        if use_deterministic:
+            click.echo(
+                "\nPhase 2: Building deterministic SPARQL (person-anchored, "
+                "no LLM)...",
+                err=True,
+            )
+            sparql_query = _build_deterministic_sparql(vars_with_uris)
+            mapped = [v["name"] for v in vars_with_uris if v.get("levels")]
+            raw = [v["name"] for v in vars_with_uris if not v.get("levels")]
+            if mapped:
+                click.echo(
+                    f"  Mapped coded values using data-element levels: "
+                    f"{', '.join(mapped)}",
+                    err=True,
+                )
+            if raw:
+                click.echo(
+                    f"  Returned raw (no value-level definitions in the data): "
+                    f"{', '.join(raw)}",
+                    err=True,
+                )
+        else:
+            click.echo("\nPhase 2: Generating SPARQL query (AI)...", err=True)
+            system_prompt = _build_sparql_prompt(vars_with_uris, prefixes, projects)
+            ai_response = _send_to_ai(system_prompt, q)
+            sparql_query = _extract_sparql(ai_response)
+
+            if not sparql_query:
+                click.echo(
+                    "Error: Could not extract a SPARQL query from the AI response.",
+                    err=True,
+                )
+                click.echo(f"AI response:\n{ai_response}", err=True)
+                return
 
         # Make the query self-contained: prepend any PREFIX declarations
-        # the AI omitted, so the shown/executed SPARQL is portable.
+        # that may be missing, so the shown/executed SPARQL is portable.
         sparql_query = _ensure_prefixes(sparql_query, prefixes)
 
         if show_query:

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import re
 import sys
 import click
+import requests
 from rdflib import Graph, Literal, Namespace
 from nidm.experiment.tools.click_base import cli
 
@@ -624,9 +625,25 @@ You MUST use the exact URIs listed below — do NOT substitute or invent URIs.
 # ---------------------------------------------------------------------------
 
 
-def _get_api_key():
-    """Get the API key from environment or config file."""
-    key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
+def _get_api_key(provider=None):
+    """Get the API key for *provider* from the environment or config file.
+
+    When the provider is known, the provider-specific env var is used so the
+    correct key is selected even if both ANTHROPIC_API_KEY and OPENAI_API_KEY
+    are set:
+      - "openai"    -> OPENAI_API_KEY
+      - "anthropic" -> ANTHROPIC_API_KEY
+      - "llama"     -> None (a local server needs no key)
+    With no provider, falls back to whichever key is present (Anthropic first).
+    """
+    if provider == "llama":
+        return None
+    if provider == "openai":
+        key = os.environ.get("OPENAI_API_KEY")
+    elif provider == "anthropic":
+        key = os.environ.get("ANTHROPIC_API_KEY")
+    else:
+        key = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("OPENAI_API_KEY")
     if key:
         return key
     config_path = Path.home() / ".pynidm" / "config.json"
@@ -637,11 +654,23 @@ def _get_api_key():
 
 
 def _get_provider():
-    """Determine which AI provider to use based on available API key."""
+    """Determine which AI provider to use.
+
+    Precedence: explicit PYNIDM_AI_PROVIDER env var, then a cloud API key in the
+    environment, then a configured local LLaMA server (PYNIDM_LLAMA_URL), then
+    ~/.pynidm/config.json.  Valid providers: "anthropic", "openai", "llama"
+    (a local OpenAI-compatible server such as llama.cpp's llama-server or
+    Ollama).
+    """
+    explicit = os.environ.get("PYNIDM_AI_PROVIDER")
+    if explicit:
+        return explicit.strip().lower()
     if os.environ.get("ANTHROPIC_API_KEY"):
         return "anthropic"
     if os.environ.get("OPENAI_API_KEY"):
         return "openai"
+    if os.environ.get("PYNIDM_LLAMA_URL"):
+        return "llama"
     config_path = Path.home() / ".pynidm" / "config.json"
     if config_path.exists():
         config = json.loads(config_path.read_text())
@@ -654,6 +683,15 @@ def _get_provider():
 # model deprecation doesn't require a code change.  (The previous
 # hard-coded "claude-sonnet-4-20250514" was retired and now 404s.)
 _ANTHROPIC_MODEL = os.environ.get("PYNIDM_ANTHROPIC_MODEL", "claude-sonnet-4-6")
+
+# Local LLaMA / OpenAI-compatible server (llama.cpp's llama-server, Ollama, ...).
+# No API key required.  PYNIDM_LLAMA_URL is the OpenAI-compatible base URL
+# (default = llama.cpp's llama-server on :8080); set to e.g.
+# http://localhost:11434/v1 for Ollama.  PYNIDM_LLAMA_MODEL is the model name to
+# request (llama.cpp serves whatever model it was started with and ignores it;
+# Ollama requires the model tag, e.g. "llama3").
+_LLAMA_URL = os.environ.get("PYNIDM_LLAMA_URL", "http://localhost:8080/v1")
+_LLAMA_MODEL = os.environ.get("PYNIDM_LLAMA_MODEL", "local-model")
 
 
 def _query_anthropic(system_prompt, user_question, api_key):
@@ -701,16 +739,64 @@ def _query_openai(system_prompt, user_question, api_key):
     return response.choices[0].message.content
 
 
+def _query_llama(system_prompt, user_question):
+    """Send a query to a local OpenAI-compatible LLM server (llama.cpp's
+    llama-server, Ollama, etc.).  No API key is required; the endpoint is
+    configured via PYNIDM_LLAMA_URL / PYNIDM_LLAMA_MODEL.
+    """
+    url = _LLAMA_URL.rstrip("/") + "/chat/completions"
+    payload = {
+        "model": _LLAMA_MODEL,
+        "messages": [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_question},
+        ],
+        "max_tokens": 4096,
+        # deterministic generation for SPARQL/concept extraction
+        "temperature": 0,
+        "stream": False,
+    }
+    try:
+        resp = requests.post(url, json=payload, timeout=600)
+        resp.raise_for_status()
+    except requests.exceptions.ConnectionError:
+        click.echo(
+            f"Error: could not connect to a local LLM server at {_LLAMA_URL}. "
+            "Start one (e.g. `llama-server -m <model>.gguf` on :8080, or "
+            "`ollama serve`) and/or set PYNIDM_LLAMA_URL.",
+            err=True,
+        )
+        sys.exit(1)
+    except requests.exceptions.RequestException as e:
+        click.echo(f"Error querying local LLM server at {url}: {e}", err=True)
+        sys.exit(1)
+
+    try:
+        return resp.json()["choices"][0]["message"]["content"]
+    except (ValueError, KeyError, IndexError) as e:
+        click.echo(
+            f"Error: unexpected response from local LLM server at {url}: {e}",
+            err=True,
+        )
+        sys.exit(1)
+
+
 def _send_to_ai(system_prompt, user_question):
     """Send a question to the configured AI provider."""
     provider = _get_provider()
-    api_key = _get_api_key()
 
+    # Local LLaMA / OpenAI-compatible server: no API key required.
+    if provider == "llama":
+        return _query_llama(system_prompt, user_question)
+
+    api_key = _get_api_key(provider)
     if not api_key:
         click.echo(
-            "Error: No API key found. Set one of:\n"
+            "Error: No AI provider configured. Set one of:\n"
             "  - ANTHROPIC_API_KEY environment variable\n"
             "  - OPENAI_API_KEY environment variable\n"
+            "  - PYNIDM_AI_PROVIDER=llama (+ optional PYNIDM_LLAMA_URL / "
+            "PYNIDM_LLAMA_MODEL) for a local OpenAI-compatible LLM server\n"
             "  - ~/.pynidm/config.json with "
             '{"provider": "anthropic", "api_key": "sk-ant-..."}',
             err=True,

--- a/tests/experiment/tools/test_nidm_queryai.py
+++ b/tests/experiment/tools/test_nidm_queryai.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 from pathlib import Path
-from nidm.experiment.tools.nidm_queryai import _extract_data_elements
+from rdflib import Graph
+from nidm.experiment.tools.nidm_queryai import (
+    _extract_data_elements,
+    _build_deterministic_sparql,
+    _looks_analytical,
+)
 
 
 def test_extract_data_elements_captures_value_levels(tmp_path: Path) -> None:
@@ -92,3 +97,122 @@ def test_get_api_key_is_provider_aware(monkeypatch) -> None:
     assert _get_api_key("openai") == "sk-oai-yyy"
     assert _get_api_key("anthropic") == "sk-ant-xxx"
     assert _get_api_key("llama") is None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic Phase-2 SPARQL builder
+# ---------------------------------------------------------------------------
+
+
+def test_looks_analytical_routing() -> None:
+    """Plain 'retrieve these variables' questions are NOT analytical (they use
+    the deterministic builder); aggregation/filter/group-by questions ARE (they
+    fall back to the LLM)."""
+    retrieval = [
+        "Retrieve age, sex, diagnosis, VIQ, PIQ, FIQ, and hippocampus volume",
+        "Map sex to 'M' and 'F' using the data element properties",
+        "show age and sex for all subjects",
+        "list every subject's diagnosis and FIQ",
+    ]
+    analytical = [
+        "What is the average age of male subjects?",
+        "How many subjects are there?",
+        "average hippocampus volume per diagnosis",
+        "count subjects by sex",
+        "subjects older than 10",
+        "distribution of FIQ",
+        "correlation between age and hippocampus volume",
+    ]
+    for q in retrieval:
+        assert _looks_analytical(q) is False, q
+    for q in analytical:
+        assert _looks_analytical(q) is True, q
+
+
+def test_build_deterministic_sparql_anchors_each_var_and_maps_only_from_levels() -> None:
+    """Each variable gets its own OPTIONAL block anchored back to the SAME
+    zero-stripped subject id (no floating entities -> no cartesian product),
+    and a coded->label mapping is emitted ONLY for a variable that carries
+    value levels."""
+    q = _build_deterministic_sparql(
+        [
+            {"name": "age", "uri": "http://x/AGE"},
+            {"name": "sex", "uri": "http://x/SEX", "levels": {"1": "Male", "2": "Female"}},
+            {"name": "left hippocampus volume", "uri": "http://x/fs_LH"},
+        ]
+    )
+    # one anchored OPTIONAL per variable
+    assert q.count("OPTIONAL {") == 3
+    # every block re-anchors to the shared subject id (driver + 3 blocks = 4)
+    assert q.count('REPLACE(STR(') == 4
+    assert q.count("prov:wasGeneratedBy/prov:qualifiedAssociation/prov:agent") == 3
+    # value mapping ONLY where levels exist
+    assert 'IF(?sex_code = "1", "Male"' in q
+    assert "?age_code" not in q and "?left_hippocampus_volume_code" not in q
+    # full URIs used as predicates (portable, no prefix guessing)
+    assert "<http://x/AGE>" in q and "<http://x/fs_LH>" in q
+
+
+def test_deterministic_query_joins_across_zero_padding_without_cartesian(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: a demographics file (id '50772') and a derivative file
+    (id '0050772', different Person node) with a left+right measure pair on ONE
+    entity must yield exactly ONE row per subject -- the volumes joined to the
+    right demographics despite the padding mismatch, and NO left x right
+    explosion."""
+    ns = (
+        "@prefix prov: <http://www.w3.org/ns/prov#> .\n"
+        "@prefix ndar: <https://ndar.nih.gov/api/datadictionary/v2/dataelement/> .\n"
+        "@prefix niiri: <http://iri.nidash.org/> .\n"
+        "@prefix x: <http://x/> .\n"
+    )
+
+    def subj(person, sid, ent, act, triples):
+        return (
+            f"niiri:{person} a prov:Agent, prov:Person ; ndar:src_subject_id \"{sid}\" .\n"
+            f"niiri:{act} a prov:Activity ; "
+            f"prov:qualifiedAssociation [ a prov:Association ; prov:agent niiri:{person} ] .\n"
+            f"niiri:{ent} a prov:Entity ; prov:wasGeneratedBy niiri:{act} ; {triples} .\n"
+        )
+
+    # demographics: ids are zero-stripped
+    demo = ns + subj("pA", "50772", "eA", "aA", 'x:AGE "11" ; x:SEX "1"') + subj(
+        "pB", "50773", "eB", "aB", 'x:AGE "12" ; x:SEX "2"'
+    )
+    # derivatives: ids are zero-padded; LH+RH live on ONE entity per subject
+    deriv = ns + subj(
+        "pC", "0050772", "eC", "aC", 'x:fs_LH "100.0" ; x:fs_RH "200.0"'
+    ) + subj("pD", "0050773", "eD", "aD", 'x:fs_LH "300.0" ; x:fs_RH "400.0"')
+
+    (tmp_path / "demo.ttl").write_text(demo, encoding="utf-8")
+    (tmp_path / "deriv.ttl").write_text(deriv, encoding="utf-8")
+
+    g = Graph()
+    g.parse(tmp_path / "demo.ttl", format="turtle")
+    g.parse(tmp_path / "deriv.ttl", format="turtle")
+
+    query = _build_deterministic_sparql(
+        [
+            {"name": "age", "uri": "http://x/AGE"},
+            {"name": "sex", "uri": "http://x/SEX", "levels": {"1": "Male", "2": "Female"}},
+            {"name": "lh", "uri": "http://x/fs_LH"},
+            {"name": "rh", "uri": "http://x/fs_RH"},
+        ]
+    )
+    rows = list(g.query(query))
+    by_sid = {str(r["subject_id"]): r for r in rows}
+
+    # exactly one row per subject (no cartesian, no duplicate Person-node rows)
+    assert len(rows) == 2, [tuple(map(str, r)) for r in rows]
+    assert set(by_sid) == {"50772", "50773"}
+
+    # cross-file join is correct AND the LH/RH pair did not explode
+    r = by_sid["50772"]
+    assert str(r["age"]) == "11"
+    assert str(r["sex"]) == "Male"  # mapped from levels
+    assert str(r["lh"]) == "100.0" and str(r["rh"]) == "200.0"
+
+    r = by_sid["50773"]
+    assert str(r["sex"]) == "Female"
+    assert str(r["lh"]) == "300.0" and str(r["rh"]) == "400.0"

--- a/tests/experiment/tools/test_nidm_queryai.py
+++ b/tests/experiment/tools/test_nidm_queryai.py
@@ -75,6 +75,7 @@ def test_query_llama_posts_openai_format_and_parses(monkeypatch) -> None:
     def _fake_post(url, json=None, timeout=None):
         captured["url"] = url
         captured["payload"] = json
+        captured["timeout"] = timeout
         return _FakeResp()
 
     monkeypatch.setattr(q.requests, "post", _fake_post)

--- a/tests/experiment/tools/test_nidm_queryai.py
+++ b/tests/experiment/tools/test_nidm_queryai.py
@@ -36,3 +36,59 @@ niiri:DX_nolevels a nidm:PersonalDataElement ;
     assert sex.get("levels") == {"1": "Male", "2": "Female"}
     # No level definitions -> no 'levels' key -> queryai must not fabricate a mapping
     assert "levels" not in dx
+
+
+def test_get_provider_selects_local_llama(monkeypatch) -> None:
+    """A configured local LLaMA server (PYNIDM_LLAMA_URL) selects the 'llama'
+    provider when no cloud key is present; an explicit PYNIDM_AI_PROVIDER wins."""
+    from nidm.experiment.tools.nidm_queryai import _get_provider
+
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PYNIDM_AI_PROVIDER", raising=False)
+    monkeypatch.setenv("PYNIDM_LLAMA_URL", "http://localhost:8080/v1")
+    assert _get_provider() == "llama"
+
+    monkeypatch.setenv("PYNIDM_AI_PROVIDER", "anthropic")
+    assert _get_provider() == "anthropic"
+
+
+def test_query_llama_posts_openai_format_and_parses(monkeypatch) -> None:
+    """_query_llama POSTs an OpenAI chat payload to <url>/chat/completions and
+    returns choices[0].message.content (no API key, no real server)."""
+    from nidm.experiment.tools import nidm_queryai as q
+
+    captured = {}
+
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"choices": [{"message": {"content": "SELECT * WHERE {}"}}]}
+
+    def _fake_post(url, json=None, timeout=None):
+        captured["url"] = url
+        captured["payload"] = json
+        return _FakeResp()
+
+    monkeypatch.setattr(q.requests, "post", _fake_post)
+
+    out = q._query_llama("SYS_PROMPT", "USER_QUESTION")
+    assert out == "SELECT * WHERE {}"
+    assert captured["url"].endswith("/chat/completions")
+    msgs = captured["payload"]["messages"]
+    assert msgs[0]["role"] == "system" and msgs[0]["content"] == "SYS_PROMPT"
+    assert msgs[1]["role"] == "user" and msgs[1]["content"] == "USER_QUESTION"
+
+
+def test_get_api_key_is_provider_aware(monkeypatch) -> None:
+    """The provider-specific key is selected even when both are set, so
+    PYNIDM_AI_PROVIDER=openai uses OPENAI_API_KEY (not the Anthropic key)."""
+    from nidm.experiment.tools.nidm_queryai import _get_api_key
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-xxx")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-oai-yyy")
+    assert _get_api_key("openai") == "sk-oai-yyy"
+    assert _get_api_key("anthropic") == "sk-ant-xxx"
+    assert _get_api_key("llama") is None


### PR DESCRIPTION
Problem
For multi-variable retrieval questions, queryai asked the LLM to author the entire SPARQL join. That made results non-deterministic and frequently wrong, independent of model quality:

Cartesian products. A value block whose carrying entity wasn't tied back to the subject (e.g. left/right hippocampus volumes) ranged over every subject, pairing one subject's demographics with all subjects' volumes — hundreds of bogus rows per subject.
Cross-file no-matches. The same human appears under different prov:Person nodes in different files, with differently zero-padded ids (50772 in demographics vs 0050772 in a FreeSurfer/FSL derivative). A join on the raw id string silently matches nothing.
Model variance. Qwen-7B emitted SQL CASE (invalid SPARQL); Qwen-14B and Claude each produced different, differently-broken joins.

Fix
For plain "retrieve these variables" questions, Phase 2 now builds the SPARQL in code from the Phase-1-resolved DataElement URIs. The model only resolves concepts; it never writes the join. The generated query:

anchors every variable back to the same subject through the universal NIDM provenance path (entity → prov:wasGeneratedBy → activity → prov:qualifiedAssociation → prov:agent → Person), each in its own OPTIONAL so a missing value yields a blank rather than dropping the subject;
matches subject ids after stripping leading zeros, so demographics and derivative files line up across the padding mismatch;
maps coded values to labels only when the DataElement defines value levels (reproschema:choices), otherwise returns raw and prints a note — it never fabricates a mapping.

A new -m / --mode {auto,deterministic,llm} flag controls this. auto (default) uses the deterministic builder for retrieval and routes analytical questions (count/average/group-by/filter) to the LLM. The LLM fallback prompt was also hardened (anchor every value to a subject; join cross-file subjects by zero-stripped id).
Result
The same retrieval query now returns byte-identical, correct results on Qwen-7B, Qwen-14B, or Claude — one row per subject, no cartesian explosion, FreeSurfer volumes correctly joined to demographics.
Tests
Added test_nidm_queryai.py coverage: intent routing, builder structure/value-mapping, and an end-to-end rdflib test proving one row per subject, correct cross-padding join, and no left×right explosion. README and ReadTheDocs updated with a "Query modes" section.