### PR TITLE
v4.5.0: linkable derivatives + flexible queryai -nl + pandas-2 fix

### DIFF
--- a/src/nidm/experiment/tools/csv2nidm.py
+++ b/src/nidm/experiment/tools/csv2nidm.py
@@ -6,7 +6,7 @@ pick a term to associate with the variable name.  The resulting annotated CSV
 data will then be written to a NIDM data file.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 from argparse import ArgumentParser
 from io import StringIO
@@ -964,11 +964,14 @@ def csv2nidm_main(args=None):
             # re-read data file with constraint that key field is read as string
             df = pd.read_csv(args.csv_file, dtype={id_field: str})
 
-        # add namespace for derived data software
-        project.addNamespace(
-            project.safe_string(software_metadata["title"].to_string(index=False)),
-            software_metadata["url"].to_string(index=False),
-        )
+        # add namespace for derived data software.  software_metadata is
+        # only defined when -derivative is supplied, so guard this block;
+        # without the guard a plain CSV->NIDM run raises UnboundLocalError.
+        if args.derivative:
+            project.addNamespace(
+                project.safe_string(software_metadata["title"].to_string(index=False)),
+                software_metadata["url"].to_string(index=False),
+            )
 
         # get namespaces from document for use later....
         rdfs_ns = project.find_namespace_with_uri(
@@ -1008,9 +1011,34 @@ def csv2nidm_main(args=None):
                 # store other data from row with columns_to_term mappings
                 for row_variable, row_data in csv_row.items():
                     # check if row_variable is subject id, if so skip it
-                    if (row_variable == id_field) or (
-                        row_variable in ["ses", "task", "run"]
-                    ):
+                    if row_variable == id_field:
+                        continue
+                    # No BIDS experiment NIDM file was supplied (fresh-file
+                    # derivative), so rather than dropping ses/task/run store them
+                    # directly on the derivative entity under the SAME predicates
+                    # bidsmri2nidm writes on the image AcquisitionObject
+                    # (bids:session_number, nidm:Task, nidm:AcquisitionObject).
+                    # This lets the derived data be linked back to the correct
+                    # image acquisition by subject_id + ses + task + run when both
+                    # the derivative and experiment NIDM files are queried together.
+                    elif row_variable in ["ses", "task", "run"]:
+                        if str(row_data) not in ("nan", ""):
+                            if row_variable == "ses":
+                                der_entity.add_attributes(
+                                    {Constants.BIDS["session_number"]: str(row_data)}
+                                )
+                            elif row_variable == "task":
+                                der_entity.add_attributes(
+                                    {Constants.NIDM_MRI_FUNCTION_TASK: str(row_data)}
+                                )
+                            else:  # run -> stored as an int to match the experiment
+                                try:
+                                    run_val = int(str(row_data))
+                                except ValueError:
+                                    run_val = str(row_data)
+                                der_entity.add_attributes(
+                                    {Constants.NIDM_ACQUISITION_ENTITY: run_val}
+                                )
                         continue
                     elif row_variable == "source_url":
                         der_entity.add_attributes(
@@ -1164,7 +1192,7 @@ def csv2nidm_main(args=None):
                 )
 
                 # store other data from row with columns_to_term mappings
-                for row_variable, row_data in csv_row.iteritems():
+                for row_variable, row_data in csv_row.items():
                     if not row_data:
                         continue
 

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -17,6 +17,7 @@ import click
 from rdflib import Graph, Literal, Namespace
 import requests
 from nidm.experiment.tools.click_base import cli
+from nidm.experiment.tools.nidm_file_utils import expand_nidm_file_list
 
 # ---------------------------------------------------------------------------
 # Namespace constants
@@ -1074,7 +1075,19 @@ def _format_results(results):
     "--nidm_file_list",
     "-nl",
     required=True,
-    help="A comma-separated list of NIDM files with full path.",
+    help="Comma-separated list of NIDM inputs.  Each entry may be a NIDM file "
+    "with full path, a directory (recursed for **/nidm.ttl), a manifest text "
+    "file (.txt/.list, one entry per line, # comments allowed), a glob, or an "
+    "http(s) URL.",
+)
+@click.option(
+    "--with_cdes",
+    "-wc",
+    is_flag=True,
+    default=False,
+    help="Also load the bundled FreeSurfer/FSL/ANTS CDE files (local copy if "
+    "present, else downloaded) so brain-volume concepts resolve without "
+    "listing them by hand.",
 )
 @click.option(
     "--question",
@@ -1111,7 +1124,7 @@ def _format_results(results):
     "'retrieve these variables' questions and the AI for analytical ones "
     "(counts, averages, group-by, filtering).",
 )
-def queryai(nidm_file_list, question, output_file, show_query, mode):
+def queryai(nidm_file_list, with_cdes, question, output_file, show_query, mode):
     """AI-assisted natural-language query of NIDM files.
 
     Uses a two-phase approach:
@@ -1134,9 +1147,21 @@ def queryai(nidm_file_list, question, output_file, show_query, mode):
       pynidm queryai -nl data/nidm.ttl   (interactive mode)
     """
 
-    # Parse file list
-    nidm_files = [f.strip() for f in nidm_file_list.split(",") if f.strip()]
+    # Expand -nl entries (files, directories recursed for **/nidm.ttl, manifest
+    # text files, globs, http(s) URLs) into a concrete file list; append the
+    # bundled CDE files when -wc is given so they are parsed for concepts.
+    nidm_files = expand_nidm_file_list(nidm_file_list, include_cdes=with_cdes)
+    if not nidm_files:
+        click.echo(
+            f"Error: no NIDM files found from -nl '{nidm_file_list}' "
+            "(check the path, directory, or manifest).",
+            err=True,
+        )
+        sys.exit(1)
     for f in nidm_files:
+        # URLs are fetched by rdflib at parse time; only validate local paths.
+        if f.startswith(("http://", "https://")):
+            continue
         if not os.path.isfile(f):
             click.echo(f"Error: File not found: {f}", err=True)
             sys.exit(1)

--- a/tests/experiment/tools/test_nidm_queryai.py
+++ b/tests/experiment/tools/test_nidm_queryai.py
@@ -2,12 +2,37 @@
 
 from __future__ import annotations
 from pathlib import Path
+from click.testing import CliRunner
 from rdflib import Graph
+from nidm.experiment.tools import nidm_queryai as _qai
 from nidm.experiment.tools.nidm_queryai import (
     _build_deterministic_sparql,
     _extract_data_elements,
     _looks_analytical,
+    queryai,
 )
+
+
+def test_queryai_nl_expands_directory(tmp_path: Path, monkeypatch) -> None:
+    """Regression: ``-nl <dir>`` must recurse for ``**/nidm.ttl`` (not error
+    'File not found' by treating the directory as a literal file).  We stop
+    right after file resolution so no AI/API call is made."""
+    study = tmp_path / "CMU_a"
+    study.mkdir()
+    (study / "nidm.ttl").write_text("")
+
+    captured = {}
+
+    def _fake_extract(files):
+        captured["files"] = list(files)
+        raise SystemExit(0)  # short-circuit before Phase 1 / the AI call
+
+    monkeypatch.setattr(_qai, "_extract_data_elements", _fake_extract)
+
+    result = CliRunner().invoke(queryai, ["-nl", str(study), "-q", "x"])
+
+    assert "File not found" not in result.output, result.output
+    assert captured.get("files") == [str(study / "nidm.ttl")]
 
 
 def test_extract_data_elements_captures_value_levels(tmp_path: Path) -> None:


### PR DESCRIPTION
# v4.5.0

Linkable, queryable derivatives and more flexible AI querying.

## Highlights

- **csv2nidm** now links fresh-file derivative data back to the image acquisition it came from.
- **pynidm queryai** accepts directories, globs, manifests, and URLs for `-nl` (like `pynidm query` already did).
- Fixes a **pandas ≥ 2.0** crash in csv2nidm.

## Added

- **csv2nidm — ses/task/run on fresh-file derivatives.** When `-derivative` is
  used without a base `-nidm` file, csv2nidm now writes each row's `ses`, `task`,
  and `run` onto the derivative entity under the same predicates `bidsmri2nidm`
  writes on the image acquisition object — `bids:session_number`, `nidm:Task`,
  and `nidm:AcquisitionObject` (empty values skipped). This lets derived data be
  joined back to the correct acquisition by subject + ses + task + run when the
  derivative and the BIDS-experiment NIDM files are queried together.
  (`tool_version` bumped to 1.1.0.)
- **pynidm queryai — `-wc/--with_cdes`.** Loads the bundled FreeSurfer/FSL/ANTS
  CDE files (local copy if present, else downloaded) so brain-volume concepts
  resolve without listing them by hand.

## Changed

- **pynidm queryai — flexible `-nl` inputs.** Each `-nl` entry may now be a NIDM
  file, a directory (recursed for `**/nidm.ttl`), a manifest text file
  (`.txt`/`.list`, one entry per line, `#` comments allowed), a shell glob, or an
  `http(s)` URL — matching `pynidm query`.

## Fixed

- **pynidm queryai** no longer errors `File not found` when `-nl` is given a
  directory; it now expands the directory to the NIDM files inside.
- **csv2nidm** crash on pandas ≥ 2.0 (`DataFrame.iteritems()` was removed;
  switched to `.items()`).
- **csv2nidm** `UnboundLocalError` on plain (non-`-derivative`) runs — the
  derivative-only software-metadata namespace block is now guarded.

## Upgrade notes

Backward compatible. `-nl` still accepts plain comma-separated file paths, so
existing scripts are unaffected.
