### PR TITLE
queryai: resolve direct NIDM predicates (task/session/run/filename)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     pandas
     pyarrow
     patsy
-    prov
+    prov[graph]
     pybids >= 0.12.4
     pydot ~= 1.4.2
     pygithub

--- a/src/nidm/experiment/schema/nidm_schema.yaml
+++ b/src/nidm/experiment/schema/nidm_schema.yaml
@@ -243,6 +243,12 @@ classes:
         slot_uri: nidm:Task
         range: string
         description: Task name for functional MRI
+      run:
+        slot_uri: nidm:AcquisitionObject
+        range: integer
+        description: >-
+          Run number for the acquisition (BIDS run entity).  Written by
+          bidsmri2nidm/csv2nidm as nidm:AcquisitionObject with an integer value.
       filename:
         slot_uri: nfo:filename
         range: string

--- a/src/nidm/experiment/tools/nidm_queryai.py
+++ b/src/nidm/experiment/tools/nidm_queryai.py
@@ -18,6 +18,7 @@ from rdflib import Graph, Literal, Namespace
 import requests
 from nidm.experiment.tools.click_base import cli
 from nidm.experiment.tools.nidm_file_utils import expand_nidm_file_list
+from nidm.experiment.tools.query_terms import resolve_query_term
 
 # ---------------------------------------------------------------------------
 # Namespace constants
@@ -751,6 +752,34 @@ def _build_deterministic_sparql(resolved_vars):
     )
 
 
+def _build_direct_predicate_sparql(direct_vars):
+    """Build a DISTINCT-values SELECT over NIDM/BIDS predicates stored directly
+    on entities (e.g. ``nidm:Task``, ``bids:session_number``, ``nfo:filename``).
+
+    Answers "what tasks / sessions / runs / files are in this data?" -- one
+    column per resolved predicate, distinct rows.  Unlike the person-anchored
+    :func:`_build_deterministic_sparql`, these facts are properties of the
+    acquisition/derivative objects themselves and are not joined to a subject.
+
+    *direct_vars* is a list of dicts each with at least ``uri`` and ``name``.
+    Returns the SPARQL query string.
+    """
+    used = set()
+    select_cols = []
+    blocks = []
+    for i, v in enumerate(direct_vars):
+        col = _sparql_var_name(v.get("name", f"var_{i}"), used)
+        select_cols.append(f"?{col}")
+        # each predicate is matched on its own entity variable so the columns
+        # are independent (a distinct list per predicate)
+        blocks.append(f"  ?e_{i} <{v['uri']}> ?{col} .")
+    return (
+        f"SELECT DISTINCT {' '.join(select_cols)}\n"
+        "WHERE {\n" + "\n".join(blocks) + "\n}\n"
+        f"ORDER BY {' '.join(select_cols)}\n"
+    )
+
+
 # Words/phrases that signal an analytical question (aggregation, filtering,
 # grouping) the deterministic per-subject retrieval builder does NOT handle --
 # those are routed to the LLM Phase-2 path instead.
@@ -1233,6 +1262,37 @@ def queryai(nidm_file_list, with_cdes, question, output_file, show_query, mode):
                         break
 
             if not matches:
+                # Not a DataElement -- try the direct-predicate registry.  Terms
+                # like task / session / run / filename / scan metadata are stored
+                # as predicates on the acquisition object (nidm:Task,
+                # bids:session_number, ...), not as DataElement nodes, so they
+                # never appear in `data_elements`.
+                direct = resolve_query_term(name)
+                if direct is None:
+                    for kw in concept.get("keywords", []):
+                        direct = resolve_query_term(kw)
+                        if direct:
+                            break
+                if direct is not None:
+                    click.echo(
+                        f"  Found direct NIDM predicate: {direct['qname']}",
+                        err=True,
+                    )
+                    resolved_vars.append(
+                        {
+                            "name": name,
+                            "role": role,
+                            "qname": direct["qname"],
+                            "uri": direct["uri"],
+                            "label": None,
+                            # marks this as a predicate on an entity (queried
+                            # directly) rather than a DataElement value.
+                            "direct_predicate": True,
+                        }
+                    )
+                    continue
+
+            if not matches:
                 click.echo(
                     f"  WARNING: No DataElement found for '{name}'. "
                     f"This variable will be omitted from the query.",
@@ -1293,13 +1353,26 @@ def queryai(nidm_file_list, with_cdes, question, output_file, show_query, mode):
         # ---- Phase 2: SPARQL generation ----
         # Only resolved vars that have URIs can be queried as predicates.
         vars_with_uris = [v for v in resolved_vars if v.get("uri")]
+        # Direct predicates (nidm:Task, bids:session_number, ...) are queried as
+        # properties of the acquisition/derivative object itself; DataElement
+        # vars are person-anchored.
+        direct_vars = [v for v in vars_with_uris if v.get("direct_predicate")]
+        de_vars = [v for v in vars_with_uris if not v.get("direct_predicate")]
 
-        # Decide how to build the query.  The deterministic builder handles the
-        # common per-subject retrieval intent reproducibly; the AI handles
+        # Decide how to build the query.  The direct builder lists distinct
+        # values of direct predicates; the deterministic builder handles the
+        # common per-subject DataElement retrieval reproducibly; the AI handles
         # analytical questions (counts/averages/group-by/filtering) and any
         # case where no variable resolved to a URI.
-        use_deterministic = mode == "deterministic" or (
-            mode == "auto" and vars_with_uris and not _looks_analytical(q)
+        use_direct = (
+            mode in ("auto", "deterministic")
+            and direct_vars
+            and not de_vars
+            and not _looks_analytical(q)
+        )
+        use_deterministic = (not use_direct) and (
+            mode == "deterministic"
+            or (mode == "auto" and de_vars and not _looks_analytical(q))
         )
         if mode == "deterministic" and not vars_with_uris:
             click.echo(
@@ -1309,13 +1382,19 @@ def queryai(nidm_file_list, with_cdes, question, output_file, show_query, mode):
             )
             use_deterministic = False
 
-        if use_deterministic:
+        if use_direct:
+            click.echo(
+                "\nPhase 2: Building direct-predicate SPARQL (no LLM)...",
+                err=True,
+            )
+            sparql_query = _build_direct_predicate_sparql(direct_vars)
+        elif use_deterministic:
             click.echo(
                 "\nPhase 2: Building deterministic SPARQL (person-anchored, "
                 "no LLM)...",
                 err=True,
             )
-            sparql_query = _build_deterministic_sparql(vars_with_uris)
+            sparql_query = _build_deterministic_sparql(de_vars or vars_with_uris)
             mapped = [v["name"] for v in vars_with_uris if v.get("levels")]
             raw = [v["name"] for v in vars_with_uris if not v.get("levels")]
             if mapped:

--- a/src/nidm/experiment/tools/query_terms.py
+++ b/src/nidm/experiment/tools/query_terms.py
@@ -1,0 +1,101 @@
+"""Registry of natural-language query terms -> direct NIDM/BIDS predicates.
+
+Some NIDM facts are stored as *direct predicates* on entities rather than as
+``nidm:DataElement`` / ``nidm:PersonalDataElement`` nodes.  For example
+``bidsmri2nidm`` / ``csv2nidm`` write, on the imaging acquisition object::
+
+    niiri:...  nidm:Task "rest"^^xsd:string ;
+               bids:session_number "1"^^xsd:string ;
+               nidm:AcquisitionObject 1 ;          # run number
+               nfo:filename "bids::...bold.nii.gz" .
+
+These are genuine NIDM-ontology terms, but they have no ``nidm:sourceVariable``,
+so queryai's DataElement resolver cannot find them and a question like
+"what tasks are in this data?" silently drops the ``task`` variable.
+
+This module maps common query phrasings to the predicate URI they denote so
+queryai can resolve them.  The predicates below correspond one-for-one to the
+``slot_uri`` values declared in ``src/nidm/experiment/schema/nidm_schema.yaml``
+(the source of truth) -- e.g. ``AcquisitionObject.task -> nidm:Task``,
+``Session.session_number -> bids:session_number`` -- plus a few BIDS
+scan-metadata predicates the tools write as raw triples.
+"""
+import re
+
+# Canonical namespaces (kept in sync with nidm.core.Constants).
+_NIDM = "http://purl.org/nidash/nidm#"
+_BIDS = "http://bids.neuroimaging.io/"
+_NFO = "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#"
+
+# term (lower-case) -> (qname, full_uri).  Terms mirror the schema slot_uris.
+_REGISTRY = {
+    # -- schema-modeled predicates -----------------------------------------
+    "task": ("nidm:Task", _NIDM + "Task"),
+    "tasks": ("nidm:Task", _NIDM + "Task"),
+    "session": ("bids:session_number", _BIDS + "session_number"),
+    "sessions": ("bids:session_number", _BIDS + "session_number"),
+    "ses": ("bids:session_number", _BIDS + "session_number"),
+    "session number": ("bids:session_number", _BIDS + "session_number"),
+    "session_number": ("bids:session_number", _BIDS + "session_number"),
+    "run": ("nidm:AcquisitionObject", _NIDM + "AcquisitionObject"),
+    "runs": ("nidm:AcquisitionObject", _NIDM + "AcquisitionObject"),
+    "file": ("nfo:filename", _NFO + "filename"),
+    "files": ("nfo:filename", _NFO + "filename"),
+    "filename": ("nfo:filename", _NFO + "filename"),
+    "filenames": ("nfo:filename", _NFO + "filename"),
+    "modality": ("nidm:hadAcquisitionModality", _NIDM + "hadAcquisitionModality"),
+    "acquisition modality": (
+        "nidm:hadAcquisitionModality",
+        _NIDM + "hadAcquisitionModality",
+    ),
+    "contrast": ("nidm:hadImageContrastType", _NIDM + "hadImageContrastType"),
+    "contrast type": ("nidm:hadImageContrastType", _NIDM + "hadImageContrastType"),
+    "image contrast": ("nidm:hadImageContrastType", _NIDM + "hadImageContrastType"),
+    "usage": ("nidm:hadImageUsageType", _NIDM + "hadImageUsageType"),
+    "usage type": ("nidm:hadImageUsageType", _NIDM + "hadImageUsageType"),
+    "image usage": ("nidm:hadImageUsageType", _NIDM + "hadImageUsageType"),
+    # -- curated BIDS scan-metadata (written as raw triples) ----------------
+    "echo time": ("bids:EchoTime", _BIDS + "EchoTime"),
+    "echotime": ("bids:EchoTime", _BIDS + "EchoTime"),
+    "flip angle": ("bids:FlipAngle", _BIDS + "FlipAngle"),
+    "flipangle": ("bids:FlipAngle", _BIDS + "FlipAngle"),
+    "phase encoding direction": (
+        "bids:PhaseEncodingDirection",
+        _BIDS + "PhaseEncodingDirection",
+    ),
+    "phase encoding": (
+        "bids:PhaseEncodingDirection",
+        _BIDS + "PhaseEncodingDirection",
+    ),
+    "slice timing": ("bids:SliceTiming", _BIDS + "SliceTiming"),
+}
+
+
+def query_term_registry():
+    """Return ``{term: {"qname": curie, "uri": full_uri}}`` for every
+    direct-predicate query term."""
+    return {t: {"qname": q, "uri": u} for t, (q, u) in _REGISTRY.items()}
+
+
+def resolve_query_term(name):
+    """Resolve a natural-language *name* to a direct-predicate descriptor.
+
+    Returns ``{"term": matched_term, "qname": curie, "uri": full_uri}`` or
+    ``None``.  Matching is case-insensitive on the whole phrase first, then
+    falls back to individual words (so "the task" / "functional task" match
+    ``task``).
+    """
+    if not name:
+        return None
+    key = name.strip().lower()
+    if key in _REGISTRY:
+        qname, uri = _REGISTRY[key]
+        return {"term": key, "qname": qname, "uri": uri}
+    for word in reversed(re.findall(r"[a-z_]+", key)):
+        if word in _REGISTRY:
+            qname, uri = _REGISTRY[word]
+            return {"term": word, "qname": qname, "uri": uri}
+    return None
+
+
+__all__ = ["query_term_registry", "resolve_query_term"]

--- a/tests/experiment/tools/test_queryai_direct_predicates.py
+++ b/tests/experiment/tools/test_queryai_direct_predicates.py
@@ -1,0 +1,63 @@
+"""Tests for queryai resolution of direct NIDM/BIDS predicates.
+
+Facts like the functional task (``nidm:Task``), session (``bids:session_number``),
+run (``nidm:AcquisitionObject``) and filename (``nfo:filename``) are stored as
+predicates on the acquisition object, not as ``nidm:DataElement`` nodes, so the
+DataElement resolver cannot find them.  The query-terms registry lets queryai
+resolve them, and the direct-predicate builder lists their distinct values.
+"""
+from rdflib import Graph, Literal, Namespace, URIRef
+from rdflib.namespace import RDF, XSD
+from nidm.experiment.tools.nidm_queryai import _build_direct_predicate_sparql
+from nidm.experiment.tools.query_terms import query_term_registry, resolve_query_term
+
+NIDM = Namespace("http://purl.org/nidash/nidm#")
+BIDS = Namespace("http://bids.neuroimaging.io/")
+NFO = Namespace("http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#")
+
+
+def test_registry_resolves_core_terms():
+    """task/session/run/filename resolve to their predicate URIs."""
+    assert resolve_query_term("task")["uri"] == str(NIDM.Task)
+    assert resolve_query_term("Task")["uri"] == str(NIDM.Task)  # case-insensitive
+    assert resolve_query_term("session")["uri"] == str(BIDS.session_number)
+    assert resolve_query_term("run")["uri"] == str(NIDM.AcquisitionObject)
+    assert resolve_query_term("filename")["uri"] == str(NFO.filename)
+    assert resolve_query_term("nonsense-not-a-term") is None
+
+
+def test_registry_core_terms_match_schema_slot_uris():
+    """The core terms use the predicate CURIEs declared in nidm_schema.yaml."""
+    reg = query_term_registry()
+    assert reg["task"]["qname"] == "nidm:Task"
+    assert reg["session_number"]["qname"] == "bids:session_number"
+    assert reg["filename"]["qname"] == "nfo:filename"
+
+
+def test_resolve_falls_back_to_trailing_word():
+    """A phrase like 'functional task' still resolves via its trailing word."""
+    assert resolve_query_term("functional task")["uri"] == str(NIDM.Task)
+
+
+def test_build_direct_predicate_sparql_selects_distinct():
+    """The builder emits a DISTINCT select over the predicate."""
+    q = _build_direct_predicate_sparql([{"name": "task", "uri": str(NIDM.Task)}])
+    assert "SELECT DISTINCT ?task" in q
+    assert f"<{NIDM.Task}>" in q
+
+
+def test_direct_predicate_query_returns_task_values():
+    """End to end: the built query lists the distinct tasks in a graph."""
+    q = _build_direct_predicate_sparql([{"name": "task", "uri": str(NIDM.Task)}])
+
+    g = Graph()
+    ao1, ao2, ao3 = (URIRef(f"http://ex/ao{i}") for i in (1, 2, 3))
+    for ao in (ao1, ao2, ao3):
+        g.add((ao, RDF.type, NIDM.AcquisitionObject))
+    g.add((ao1, NIDM.Task, Literal("rest", datatype=XSD.string)))
+    g.add((ao2, NIDM.Task, Literal("rest", datatype=XSD.string)))
+    g.add((ao3, NIDM.Task, Literal("nback", datatype=XSD.string)))
+
+    tasks = sorted(str(row[0]) for row in g.query(q))
+    # DISTINCT collapses the two "rest" rows
+    assert tasks == ["nback", "rest"]


### PR DESCRIPTION
pynidm queryai could not answer questions about scan-level facts such as the functional task, session, run, or filename. These are written by bidsmri2nidm / csv2nidm as direct predicates on the acquisition object (nidm:Task, bids:session_number, nidm:AcquisitionObject, nfo:filename) — they are genuine NIDM-ontology terms, but they have no nidm:sourceVariable, so queryai's DataElement resolver never found them and silently dropped the variable. For example:

Question: tell me what Task were included in this data
Phase 1: Identifying variables in your question...
  Resolving 'task'...
  WARNING: No DataElement found for 'task'. This variable will be omitted from the query.
What this PR does
Adds a query-terms registry (query_terms.py) mapping natural-language terms to the direct predicates they denote — task → nidm:Task, session → bids:session_number, run → nidm:AcquisitionObject, filename → nfo:filename, plus modality / contrast / usage and common BIDS scan-metadata (echo time, flip angle, phase-encoding direction, slice timing) and natural-language synonyms.
Wires queryai Phase 1 to consult the registry when a variable is not a DataElement, so task now resolves to nidm:Task instead of being dropped.
Adds a direct-predicate Phase-2 builder that emits a SELECT DISTINCT over the predicate (e.g. "what tasks are in this data?"), independent of the person-anchored DataElement builder.
Adds run to AcquisitionObject in nidm_schema.yaml so the predicate is in the schema (source of truth) alongside task / session_number / filename.
Adds tests/experiment/tools/test_queryai_direct_predicates.py (registry resolution, the builder, and an end-to-end SPARQL execution).
After
Question: tell me what Task were included in this data
Phase 1: Identifying variables in your question...
  Resolving 'task'...
  Found direct NIDM predicate: nidm:Task
Phase 2: Building direct-predicate SPARQL (no LLM)...

SELECT DISTINCT ?task
WHERE {
  ?e_0 <http://purl.org/nidash/nidm#Task> ?task .
}
ORDER BY ?task

Results:
task
----
balloonanalogrisktask