### PR TITLE
nidm_query: fix pandas>=2 crash in --get_instruments/--get_instrument…

### DIFF
--- a/src/nidm/experiment/tools/nidm_query.py
+++ b/src/nidm/experiment/tools/nidm_query.py
@@ -180,17 +180,11 @@ def query(
     elif get_instruments:
         # first get all project UUIDs then iterate and get instruments adding to output dataframe
         project_list = GetProjectsUUID(nidm_file_list.split(","))
-        count = 1
-        for project in project_list:
-            if count == 1:
-                df = GetProjectInstruments(
-                    nidm_file_list.split(","), project_id=project
-                )
-                count += 1
-            else:
-                df = df.append(
-                    GetProjectInstruments(nidm_file_list.split(","), project_id=project)
-                )
+        frames = [
+            GetProjectInstruments(nidm_file_list.split(","), project_id=project)
+            for project in project_list
+        ]
+        df = pd.concat(frames) if frames else pd.DataFrame()
 
         # write dataframe
         # if output file parameter specified
@@ -206,19 +200,11 @@ def query(
     elif get_instrument_vars:
         # first get all project UUIDs then iterate and get instruments adding to output dataframe
         project_list = GetProjectsUUID(nidm_file_list.split(","))
-        count = 1
-        for project in project_list:
-            if count == 1:
-                df = GetInstrumentVariables(
-                    nidm_file_list.split(","), project_id=project
-                )
-                count += 1
-            else:
-                df = df.append(
-                    GetInstrumentVariables(
-                        nidm_file_list.split(","), project_id=project
-                    )
-                )
+        frames = [
+            GetInstrumentVariables(nidm_file_list.split(","), project_id=project)
+            for project in project_list
+        ]
+        df = pd.concat(frames) if frames else pd.DataFrame()
 
         # write dataframe
         # if output file parameter specified


### PR DESCRIPTION
## Summary
`nidm_query --get_instruments` and `--get_instrument_vars` crash with
`AttributeError: 'DataFrame' object has no attribute 'append'` on any NIDM file
that contains more than one project.

## Root cause
Both modes accumulate per-project results with `df = df.append(...)`.
`DataFrame.append` was deprecated in pandas 1.4 and **removed in pandas 2.0**.
Because the package doesn't pin pandas, a fresh install pulls pandas 2.x/3.x,
so the call fails. Single-project files happened to avoid it (the append branch
is only reached from the second project onward), which is why it went unnoticed.

## Fix
Replace the append loop with a list comprehension + `pd.concat`. This also
returns an empty DataFrame instead of raising `NameError` when there are no
projects/instruments (e.g. a pure derivative NIDM file), so both modes now
degrade gracefully.

## How it was found / testing
Surfaced by a query-layer parity harness that runs every `nidm_query` mode over
real NIDM data (ABIDE phenotype + an OpenNeuro FreeSurfer derivative). After the
fix, all query modes run cleanly on both single- and multi-project files.

## Impact
User-facing crash fix; no API or output changes for the single-project case.