### PR TITLE
Fix `pynidm merge -s` crash on pandas ≥3 / rdflib ≥6.3 (URIRef coercion)

### DIFF
--- a/src/nidm/experiment/tools/nidm_merge.py
+++ b/src/nidm/experiment/tools/nidm_merge.py
@@ -1,7 +1,7 @@
 """Tools for working with NIDM-Experiment files"""
 
 import click
-from rdflib import Graph, util
+from rdflib import Graph, URIRef, util
 from nidm.core import Constants
 from nidm.experiment.Query import GetParticipantIDs
 from nidm.experiment.tools.click_base import cli
@@ -99,6 +99,7 @@ def merge(nidm_file_list, s, out_file):
                         uuid_replacement = first_file_subjids.iloc[
                             [*filter(t.get, t.index)][0], 0
                         ]
+                        uuid_replacement = URIRef(str(uuid_replacement))
 
                         for s, p, o in graph.triples((None, None, None)):
                             if s == row["uuid"]:


### PR DESCRIPTION
## Summary
`pynidm merge -s` (merging NIDM files on `ndar:src_subject_id`) crashes on
newer dependency stacks with a `Graph.add()` error, so subject-unifying merges
fail on non-zero exit.

## Root cause
When unifying agents that share a subject id, the replacement UUID is read out
of a pandas DataFrame. pandas ≥3 infers string dtype by default and strips the
`rdflib.URIRef` subclass down to a plain `str`; rdflib ≥6.3 then rejects that
plain `str` in `Graph.add()` (which now requires real `Node` terms), and the
triple insertion raises.

## Fix
Coerce the replacement UUID back to a `URIRef` before it is used:

```python
uuid_replacement = URIRef(str(uuid_replacement))
```

This mirrors the equivalent fix already applied in the LinkML implementation.

## Testing
- `pynidm merge -s` now completes and writes the merged graph (verified on
  ABIDE NYU + CMU_a).
- Existing merge tests pass. *(adjust if you added a regression test)*

## Notes
This is the final maintenance release of the legacy prov-toolbox line
(**v4.5.3**). Development continues on the LinkML-based, prov-free rewrite,
which will follow as **v5.0.0**.