### PR TITLE
csv2nidm: restore -nidm assessment mode (regression silently dropped / crashed on appended CSV values)

### DIFF
--- a/src/nidm/experiment/tools/csv2nidm.py
+++ b/src/nidm/experiment/tools/csv2nidm.py
@@ -838,56 +838,66 @@ def csv2nidm_main(args=None):
                         },
                     )
 
-                # if this isn't derivative data...
-                if not args.derivative:
-                    # add an assessment acquisition for the phenotype data to session and associate with agent
-                    # acq=AssessmentAcquisition(session=nidm_session)
+            # if this isn't derivative data...
+            # NOTE (regression fix): this block was accidentally nested inside
+            # `if args.derivative:` by commit ec62db1c (2025-04-08, derivative
+            # support), making it unreachable dead code -- so csv2nidm -nidm
+            # assessment mode silently dropped the appended CSV values.  Dedented
+            # back to a reachable sibling of the derivative branch, restoring the
+            # pre-2025-04 behavior (attach the values to a new assessment
+            # acquisition on the existing subject).
+            if not args.derivative:
+                # add an assessment acquisition for the phenotype data to session and associate with agent
+                # acq=AssessmentAcquisition(session=nidm_session)
 
-                    # create a new session for this assessment
-                    new_session = Session(project=project)
+                # create a new session for this assessment
+                new_session = Session(project=project)
 
-                    acq = AssessmentAcquisition(session=new_session)
-                    # add acquisition entity for assessment
-                    acq_entity = AssessmentObject(acquisition=acq)
-                    # add qualified association with existing agent
-                    acq.add_qualified_association(
-                        person=subject_uuid["person_uuid"][0],
-                        role=Constants.NIDM_PARTICIPANT,
-                    )
+                acq = AssessmentAcquisition(session=new_session)
+                # add acquisition entity for assessment
+                acq_entity = AssessmentObject(acquisition=acq)
+                # add qualified association with existing agent
+                acq.add_qualified_association(
+                    person=subject_uuid["person_uuid"][0],
+                    role=Constants.NIDM_PARTICIPANT,
+                )
 
-                    # add git-annex info if exists
-                    num_sources = addGitAnnexSources(
-                        obj=acq_entity,
-                        filepath=args.csv_file,
-                        bids_root=dirname(args.csv_file),
-                    )
-                    # if there aren't any git annex sources then just store the local directory information
-                    if num_sources == 0:
-                        # WIP: add absolute location of BIDS directory on disk for later finding of files
-                        acq_entity.add_attributes(
-                            {Constants.PROV["Location"]: "file:/" + args.csv_file}
-                        )
-
-                    # store file to acq_entity
+                # add git-annex info if exists
+                num_sources = addGitAnnexSources(
+                    obj=acq_entity,
+                    filepath=args.csv_file,
+                    bids_root=dirname(args.csv_file),
+                )
+                # if there aren't any git annex sources then just store the local directory information
+                if num_sources == 0:
+                    # WIP: add absolute location of BIDS directory on disk for later finding of files
                     acq_entity.add_attributes(
-                        {Constants.NIDM_FILENAME: basename(args.csv_file)}
+                        {Constants.PROV["Location"]: "file:/" + args.csv_file}
                     )
 
-                    # store other data from row with columns_to_term mappings
-                    for row_variable in df_row:
-                        # check if row_variable is subject id, if so skip it
-                        if row_variable == id_field:
-                            continue
-                        else:
-                            if str(df_row[row_variable]) != "nan":
-                                add_attributes_with_cde(
-                                    acq_entity,
-                                    cde,
-                                    row_variable,
-                                    Literal(df_row[row_variable]),
-                                )
+                # store file to acq_entity
+                acq_entity.add_attributes(
+                    {Constants.NIDM_FILENAME: basename(args.csv_file)}
+                )
 
-                    continue
+                # store other data from row with columns_to_term mappings.
+                # Iterate COLUMN NAMES via .keys(); a plain ``for x in df_row``
+                # iterates the Series' VALUES, so ``df_row[value]`` raised
+                # KeyError -- another latent bug in this previously-dead block.
+                for row_variable in df_row.keys():
+                    # check if row_variable is subject id, if so skip it
+                    if row_variable == id_field:
+                        continue
+                    else:
+                        if str(df_row[row_variable]) != "nan":
+                            add_attributes_with_cde(
+                                acq_entity,
+                                cde,
+                                row_variable,
+                                Literal(df_row[row_variable]),
+                            )
+
+                continue
         if args.logfile:
             logging.info("Adding CDEs to graph....")
         else:


### PR DESCRIPTION
## Summary
`csv2nidm -nidm` (append a CSV to an existing NIDM file) in **assessment mode**
(no `-derivative`) has been broken since the derivative-support rewrite
(commit ec62db1c, 2025-04-08) — present through v4.5.3. That commit accidentally
nested the assessment-acquisition block inside `if args.derivative:` (as
`if not args.derivative:`), making it **unreachable dead code**, so appending a
phenotype/assessment CSV to an existing NIDM file **silently discarded the CSV
values** (only CDE definitions were written).

Because the block was dead — and therefore untested — it also carried a second
latent bug: `for row_variable in df_row:` iterates a pandas Series' *values*, not
its column names, so once reachable it crashed with `KeyError`.

## Fix (`src/nidm/experiment/tools/csv2nidm.py`)
1. Dedent the `if not args.derivative:` assessment block to a reachable sibling of
   the `if args.derivative:` branch, restoring the pre-2025-04 behavior (attach
   the CSV values to a new assessment acquisition on the existing subject).
2. Iterate column names via `df_row.keys()` instead of `for row_variable in df_row`.

## Validation
Confirmed against the LinkML `csv2nidm` (which implements the correct behavior)
with a typed-shape legacy-vs-LinkML parity gate: with this fix, both tools produce
structurally identical graphs for `csv2nidm -nidm`.

## Release
Bug fix → `patch` (v4.5.3 → v4.5.4). Final legacy release.