### PR TITLE
bidsmri2nidm: capture BIDS field maps with a FieldMap image-usage type

### DIFF
--- a/src/nidm/core/BIDS_Constants.py
+++ b/src/nidm/core/BIDS_Constants.py
@@ -33,6 +33,17 @@ scans = {
     "dwi": Constants.NIDM_MRI_DWI_SCAN,
     "bval": Constants.NIDM_MRI_DWI_BVAL,
     "bvec": Constants.NIDM_MRI_DWI_BVEC,
+    # Field maps -- both the fmap/ datatype and the BIDS fieldmap suffixes
+    # (some datasets, e.g. ABIDE II, misplace _fieldmap scans inside dwi/).
+    "fmap": Constants.NIDM_MRI_FIELDMAP,
+    "fieldmap": Constants.NIDM_MRI_FIELDMAP,
+    "epi": Constants.NIDM_MRI_FIELDMAP,
+    "phasediff": Constants.NIDM_MRI_FIELDMAP,
+    "phase1": Constants.NIDM_MRI_FIELDMAP,
+    "phase2": Constants.NIDM_MRI_FIELDMAP,
+    "magnitude": Constants.NIDM_MRI_FIELDMAP,
+    "magnitude1": Constants.NIDM_MRI_FIELDMAP,
+    "magnitude2": Constants.NIDM_MRI_FIELDMAP,
     "T1w": Constants.NIDM_MRI_T1,
     "T2w": Constants.NIDM_MRI_T2,
     "inplaneT2": Constants.NIDM_MRI_T2,

--- a/src/nidm/core/Constants.py
+++ b/src/nidm/core/Constants.py
@@ -409,6 +409,7 @@ NIDM_MRI_ANATOMIC_SCAN = QualifiedName(provNamespace("nidm", NIDM), "Anatomical"
 NIDM_MRI_STRUCTURE_SCAN = QualifiedName(provNamespace("nidm", NIDM), "Structural")
 NIDM_MRI_FUNCTION_SCAN = QualifiedName(provNamespace("nidm", NIDM), "Functional")
 NIDM_MRI_DWI_SCAN = QualifiedName(provNamespace("nidm", NIDM), "DiffusionWeighted")
+NIDM_MRI_FIELDMAP = QualifiedName(provNamespace("nidm", NIDM), "FieldMap")
 NIDM_MRI_DWI_BVAL = QualifiedName(provNamespace("nidm", NIDM), "b-value")
 NIDM_MRI_DWI_BVEC = QualifiedName(provNamespace("nidm", NIDM), "b-vector")
 NIDM_MRI_FUNCTION_TASK = QualifiedName(provNamespace("nidm", NIDM), "Task")
@@ -638,6 +639,7 @@ nidm_experiment_terms = [
     NIDM_MRI_STRUCTURE_SCAN,
     NIDM_MRI_FUNCTION_SCAN,
     NIDM_MRI_DWI_SCAN,
+    NIDM_MRI_FIELDMAP,
     NIDM_MRI_DWI_BVAL,
     NIDM_MRI_DWI_BVEC,
     NIDM_MRI_FUNCTION_TASK,

--- a/src/nidm/experiment/tools/bidsmri2nidm.py
+++ b/src/nidm/experiment/tools/bidsmri2nidm.py
@@ -38,6 +38,22 @@ from nidm.experiment.Utils import (
     map_variables_to_terms,
 )
 
+# BIDS field-map suffixes.  These scans carry FieldMap usage regardless of the
+# directory they live in -- some datasets (e.g. ABIDE II) place _fieldmap scans
+# inside dwi/ rather than fmap/, and they must NOT be labeled DiffusionWeighted.
+_FIELDMAP_SUFFIXES = frozenset(
+    {
+        "fieldmap",
+        "epi",
+        "phasediff",
+        "phase1",
+        "phase2",
+        "magnitude",
+        "magnitude1",
+        "magnitude2",
+    }
+)
+
 
 def getRelPathToBIDS(filepath, bids_root, bidsuri_format=False):
     """
@@ -211,7 +227,7 @@ and API Keys.  Then set the environment variable INTERLEX_API_KEY with your key.
         shared_project_uuid = getUUID()
         shared_dataset_uuid = getUUID()
 
-        subjects = bids.BIDSLayout(directory).get_subjects()
+        subjects = bids.BIDSLayout(directory, validate=False).get_subjects()
         for subj in subjects:
             if subj.startswith("."):
                 continue
@@ -395,6 +411,68 @@ def addimagingsessions(
                 role=Constants.NIDM_PARTICIPANT,
             )
 
+        # Field maps (BIDS fmap suffixes) may live in a proper fmap/ directory
+        # OR be misplaced inside dwi/ (e.g. ABIDE II).  Handle them by SUFFIX so
+        # they get FieldMap usage regardless of directory, and skip the
+        # datatype-based branches below (which would mislabel a dwi/-dir fieldmap
+        # as DiffusionWeighted).  Mirrors the generic image handling: usage,
+        # filename, git-annex sources, sha512, run, and JSON sidecar.
+        if file_tpl.entities.get("suffix") in _FIELDMAP_SUFFIXES:
+            acq_obj = MRObject(acq)
+            session.graph.hadMember(collection, acq_obj)
+            acq_obj.add_attributes(
+                {Constants.NIDM_IMAGE_USAGE_TYPE: Constants.NIDM_MRI_FIELDMAP}
+            )
+            acq_obj.add_attributes(
+                {
+                    Constants.NIDM_FILENAME: getRelPathToBIDS(
+                        join(file_tpl.dirname, file_tpl.filename),
+                        directory,
+                        bidsuri_format=True,
+                    )
+                }
+            )
+            addGitAnnexSources(
+                obj=acq_obj,
+                filepath=join(file_tpl.dirname, file_tpl.filename),
+                bids_root=directory,
+            )
+            if isfile(join(directory, file_tpl.dirname, file_tpl.filename)):
+                acq_obj.add_attributes(
+                    {
+                        Constants.CRYPTO_SHA512: getsha512(
+                            join(directory, file_tpl.dirname, file_tpl.filename)
+                        )
+                    }
+                )
+            else:
+                logging.info(
+                    "WARNING file %s doesn't exist! No SHA512 sum stored in NIDM files...",
+                    join(directory, file_tpl.dirname, file_tpl.filename),
+                )
+            if "run" in file_tpl.entities:
+                acq_obj.add_attributes(
+                    {BIDS_Constants.json_keys["run"]: file_tpl.tags["run"].value}
+                )
+            json_data = _read_scan_sidecar(directory, file_tpl)
+            if len(json_data) > 0:
+                for key, value in json_data.items():
+                    normalized_key = key.replace(" ", "_")
+                    if normalized_key in BIDS_Constants.json_keys:
+                        if isinstance(value, list):
+                            acq_obj.add_attributes(
+                                {
+                                    BIDS_Constants.json_keys[normalized_key]: "".join(
+                                        str(e) for e in value
+                                    )
+                                }
+                            )
+                        else:
+                            acq_obj.add_attributes(
+                                {BIDS_Constants.json_keys[normalized_key]: value}
+                            )
+            continue
+
         if file_tpl.entities["datatype"] == "anat":
             # do something with anatomicals
             acq_obj = MRObject(acq)
@@ -463,6 +541,12 @@ def addimagingsessions(
                 logging.info(
                     "WARNING file %s doesn't exist! No SHA512 sum stored in NIDM files...",
                     join(directory, file_tpl.dirname, file_tpl.filename),
+                )
+            # add run entity if present (matches the func/dwi branches and the
+            # LinkML tool, which emit the BIDS run index on every scan)
+            if "run" in file_tpl.entities:
+                acq_obj.add_attributes(
+                    {BIDS_Constants.json_keys["run"]: file_tpl.tags["run"].value}
                 )
             # get associated JSON file if exists
             # There is T1w.json file with information
@@ -1174,7 +1258,7 @@ def bidsmri2project(
 
     # get BIDS layout
     bids.config.set_option("extension_initial_dot", True)
-    bids_layout = bids.BIDSLayout(directory)
+    bids_layout = bids.BIDSLayout(directory, validate=False)
 
     # create empty dictionary for sessions where key is subject id and used later to link scans to same session as demographics
     session = {}


### PR DESCRIPTION
Captures BIDS field-map acquisitions that were previously dropped or mislabeled, validated to produce graphs isomorphic to the LinkML refactor via typed-shape A/B on real ABIDE data.

Build the pybids layout with validate=False so real-world non-conformant files (e.g. ABIDE II field maps placed under dwi/) are captured rather than silently dropped by BIDS validation.
New nidm:FieldMap image-usage type (Constants.NIDM_MRI_FIELDMAP) plus BIDS_Constants entries for the fmap datatype and field-map suffixes (fieldmap, magnitude, magnitude1/2, phasediff, phase1/2, epi). Field-map scans are now labeled FieldMap instead of mislabeled DiffusionWeighted. (Vocabulary term proposed to nidm-experiment separately.)
Emit the BIDS run index in the anat branch (it was only emitted for func/dwi).

Validation: typed-shape parity (scripts/parity_compare.py) legacy vs LinkML — ABIDE Caltech PARITY OK (6,635 instances) and ABIDE II NYU_1 PARITY OK (42,211 instances; exercises DWI, field maps, multi-run, multi-session).